### PR TITLE
SDM scripts for HU, FI, LT, SE & SK

### DIFF
--- a/Scripts/country_spec_scripts/EES2019_fi_stack.R
+++ b/Scripts/country_spec_scripts/EES2019_fi_stack.R
@@ -1,0 +1,92 @@
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Title: Script for Stacking Observations (EES 2019 Voter Study, Finland Sample) 
+# Author: J.Leiser
+# last update: 2021-08-09
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# countrycode = 1246
+# countryshort = 'FI'
+
+# Keep the EES 2019 Finland sample # ===================================================================
+EES2019_fi <- 
+  EES2019 %>% 
+  filter(countrycode==1246)
+
+
+# Filter the codebook and EP elections data # ==========================================================
+
+EP2019_fi <- 
+  EP2019 %>% 
+  filter(countryshort=='FI')
+
+
+EES2019_cdbk_fi <- 
+  EES2019_cdbk %>% 
+  filter(countryshort=='FI')
+
+# Get the respondent ID codes # ========================================================================
+
+respid <- 
+  EES2019_fi$respid %>% 
+  as.numeric()
+
+class(respid) #check class
+
+# Choose the relevant parties # ========================================================================
+
+
+# Check the parties about which we have the PTV variable # - - - - - - - - - - - - - - - - - - - - - - -
+
+ptv_crit <-
+  EES2019_cdbk_fi %>% 
+  dplyr::select(partyname, Q10_PTV) 
+
+# ptv_crit #7 Parties with PTV score
+# Parties = SDP, Perus/PS, KOK, KESK, VIHR, VAS, RKP
+
+# Check the vote shares of parties that obtained at least one seat in the EP # - - - - - - - - - - - - -
+
+votes_crit <- 
+  EP2019_fi %>% 
+  filter(party_name!='Other parties') 
+
+# votes_crit 
+# 10 Parties
+# parties = KESK, KOK, sDP, VAS, VIHR, SFP (RKP), PS, KS, SIN, PP
+
+# from the 7 parties with a PTV variable, all 7 obtained a seat in EP election
+# only keep those 7
+
+# Select the relevant parties # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
+party <- 
+  EES2019_cdbk_fi %>% 
+  dplyr::select(partyname, Q10_PTV, Q7) %>%   
+  na.omit() %>% 
+  .$Q7
+
+# party
+
+# Create the Finland EES 2019 SDM # ====================================================================
+
+EES2019_fi_stack <- 
+  expand_grid(respid, party) %>% 
+  mutate(countrycode=EES2019_fi$countrycode %>% unique,
+         stack = paste0(respid, '-', party)) %>%
+  dplyr::select(countrycode, respid, party, stack)
+
+# Final plausibility check # ====================================================================
+
+# unique(EES2019_fi_stack$countrycode)
+# correct country code
+
+# unique(EES2019_fi$respid) %>% length()
+# unique(EES2019_fi_stack$respid) %>% length()
+# number of unique respondents IDs in both original data and SDM match
+
+# dim(EES2019_fi_stack)
+# 7000 by 4 data frame as expected (7 parties x 1000 respondents)
+
+# Clean the environment # ==============================================================================
+
+rm(list=ls(pattern='_fi$|_crit$'))  
+rm(list = c('respid', 'party'))

--- a/Scripts/country_spec_scripts/EES2019_hu_stack.R
+++ b/Scripts/country_spec_scripts/EES2019_hu_stack.R
@@ -4,7 +4,7 @@
 # last update: 2021-08-09
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # countrycode = 1348
-# countryshort = 'HU
+# countryshort = 'HU'
 
 # Keep the EES 2019 Hungary sample # ===================================================================
 EES2019_hu <- 

--- a/Scripts/country_spec_scripts/EES2019_hu_stack.R
+++ b/Scripts/country_spec_scripts/EES2019_hu_stack.R
@@ -1,0 +1,94 @@
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Title: Script for Stacking Observations (EES 2019 Voter Study, Hungary Sample) 
+# Author: J.Leiser
+# last update: 2021-08-09
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# countrycode = 1348
+# countryshort = 'HU
+
+# Keep the EES 2019 Hungary sample # ===================================================================
+EES2019_hu <- 
+  EES2019 %>% 
+  filter(countrycode==1348)
+
+# Filter the codebook and EP elections data # ==========================================================
+
+EP2019_hu <- 
+  EP2019 %>% 
+  filter(countryshort=='HU')
+
+
+EES2019_cdbk_hu <- 
+  EES2019_cdbk %>% 
+  filter(countryshort=='HU')
+
+# Get the respondent ID codes # ========================================================================
+
+respid <- 
+  EES2019_hu$respid %>% 
+  as.numeric()
+
+class(respid) #check class
+
+# Choose the relevant parties # ========================================================================
+
+
+# Check the parties about which we have the PTV variable # - - - - - - - - - - - - - - - - - - - - - - -
+
+ptv_crit <-
+  EES2019_cdbk_hu %>% 
+  dplyr::select(partyname, Q10_PTV) 
+
+# ptv_crit
+# 7 parties
+# parties = DK, FIDESZ - KDNP, JOBBIK, LMP, MSZP, MH, Momentum Mozgalum
+
+
+# Check the vote shares of parties that obtained at least one seat in the EP # - - - - - - - - - - - - -
+
+votes_crit <- 
+  EP2019_hu %>% 
+  filter(party_name!='Other parties') 
+
+# votes_crit
+# 8 parties
+# parties = DK, FIDESZ + KDNP, JOBBIK, LMP, MKKP, Momentum Mozgalom, MH,
+# MSZP + Párbeszéd
+
+# from the 7 parties with a PTV variable, all 7 obtained a seat in EP election
+# only keep those 7
+
+# Select the relevant parties # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
+party <- 
+  EES2019_cdbk_hu %>% 
+  dplyr::select(partyname, Q10_PTV, Q7) %>%   
+  na.omit() %>% 
+  .$Q7
+
+# party
+
+# Create the Hungary EES 2019 SDM # ====================================================================
+
+EES2019_hu_stack <- 
+  expand_grid(respid, party) %>% 
+  mutate(countrycode=EES2019_hu$countrycode %>% unique,
+         stack = paste0(respid, '-', party)) %>%
+  dplyr::select(countrycode, respid, party, stack)
+
+# Final plausibility check # ====================================================================
+
+# unique(EES2019_hu_stack$countrycode)
+# correct country code
+
+# unique(EES2019_hu$respid) %>% length()
+# unique(EES2019_hu_stack$respid) %>% length()
+# number of unique respondents IDs in both original data and SDM match
+
+# dim(EES2019_hu_stack)
+# 7000 by 4 data frame as expected (7 parties x 1000 respondents)
+
+# Clean the environment # ==============================================================================
+
+rm(list=ls(pattern='_hu$|_crit$'))  
+rm(list = c('respid', 'party'))

--- a/Scripts/country_spec_scripts/EES2019_lt_stack.R
+++ b/Scripts/country_spec_scripts/EES2019_lt_stack.R
@@ -1,0 +1,96 @@
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Title: Script for Stacking Observations (EES 2019 Voter Study, Lithuania Sample) 
+# Author: J.Leiser
+# last update: 2021-08-09
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# countrycode = 1440
+# countryshort = 'LT'
+
+# Keep the EES 2019 Lithuania sample # ===================================================================
+EES2019_lt <- 
+  EES2019 %>% 
+  filter(countrycode==1440)
+
+# Filter the codebook and EP elections data # ==========================================================
+
+EP2019_lt <- 
+  EP2019 %>% 
+  filter(countryshort=='LT')
+
+
+EES2019_cdbk_lt <- 
+  EES2019_cdbk %>% 
+  filter(countryshort=='LT')
+
+
+# Get the respondent ID codes # ========================================================================
+
+respid <- 
+  EES2019_lt$respid %>% 
+  as.numeric()
+
+class(respid) #check class
+
+# Choose the relevant parties # ========================================================================
+
+
+# Check the parties about which we have the PTV variable # - - - - - - - - - - - - - - - - - - - - - - -
+
+ptv_crit <-
+  EES2019_cdbk_lt %>% 
+  dplyr::select(partyname, Q10_PTV) 
+
+# ptv_crit
+# 7 parties
+# parties = TS-LKD, LSDP, LS, DP, TT, LLRA, LVZS
+
+
+# Check the vote shares of parties that obtained at least one seat in the EP # - - - - - - - - - - - - -
+
+votes_crit <- 
+  EP2019_lt %>% 
+  filter(party_name!='Other parties') 
+
+# votes_crit
+# 14 parties
+# parties = DP, LLRA-KSS, LRLS ( = LS from above), 
+# LSDP, LVZS, TT, TS-LKD, LCP, LSDDP, LZP, LLS, VKM-AMT, VKM-PRPJ, VKM-VRSV
+ 
+
+# from the 7 parties with a PTV variable, all 7 obtained a seat in EP election
+# only keep those 7
+
+# Select the relevant parties # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
+party <- 
+  EES2019_cdbk_lt %>% 
+  dplyr::select(partyname, Q10_PTV, Q7) %>%   
+  na.omit() %>% 
+  .$Q7
+
+# party
+
+# Create the Lithuania EES 2019 SDM # ====================================================================
+
+EES2019_lt_stack <- 
+  expand_grid(respid, party) %>% 
+  mutate(countrycode=EES2019_lt$countrycode %>% unique,
+         stack = paste0(respid, '-', party)) %>%
+  dplyr::select(countrycode, respid, party, stack)
+
+# Final plausibility check # ====================================================================
+
+# unique(EES2019_lt_stack$countrycode)
+# correct country code
+
+# unique(EES2019_lt$respid) %>% length()
+# unique(EES2019_lt_stack$respid) %>% length()
+# number of unique respondents IDs in both original data and SDM match
+
+# dim(EES2019_lt_stack)
+# 7000 by 4 data frame as expected (7 parties x 1000 respondents)
+
+# Clean the environment # ==============================================================================
+
+rm(list=ls(pattern='_lt$|_crit$'))  
+rm(list = c('respid', 'party'))

--- a/Scripts/country_spec_scripts/EES2019_pl_stack.R
+++ b/Scripts/country_spec_scripts/EES2019_pl_stack.R
@@ -1,0 +1,98 @@
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Title: Script for Stacking Observations (EES 2019 Voter Study, Poland Sample) 
+# Author: J.Leiser
+# last update: 2021-08-12
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# countrycode = 1616
+# countryshort = 'PL'
+
+# Keep the EES 2019 Poland sample # ===================================================================
+EES2019_pl <- 
+  EES2019 %>% 
+  filter(countrycode==1616)
+
+# Filter the codebook and EP elections data # ==========================================================
+
+EP2019_pl <- 
+  EP2019 %>% 
+  filter(countryshort=='PL')
+
+
+EES2019_cdbk_pl <- 
+  EES2019_cdbk %>% 
+  filter(countryshort=='PL')
+
+# Get the respondent ID codes # ========================================================================
+
+respid <- 
+  EES2019_pl$respid %>% 
+  as.numeric()
+
+class(respid) #check class
+
+# Choose the relevant parties # ========================================================================
+
+
+# Check the parties about which we have the PTV variable # - - - - - - - - - - - - - - - - - - - - - - -
+
+ptv_crit <-
+  EES2019_cdbk_pl %>% 
+  dplyr::select(partyname, Q10_PTV) 
+
+# ptv_crit
+# 8 parties
+# parties = PO, PSL, SLD, PIS, Kukiz '15, Wiosna Roberta Biedronia, Razem, KE
+
+
+# Check the vote shares of parties that obtained at least one seat in the EP # - - - - - - - - - - - - -
+
+votes_crit <- 
+  EP2019_pl %>% 
+  filter(party_name!='Other parties') 
+
+# votes_crit
+# 7 parties
+# parties = PiS, Konfederacja, Kukiz '15, Wiosna, KE ( = PO + PSL + SLD + others) 
+# Polska Fair Play, Coal Lewica Razem
+
+# All parties with PTV variable are in vote_crit either independently or as part of a 
+# coalition
+
+# Select the relevant parties # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
+party <- 
+  EES2019_cdbk_pl %>% 
+  dplyr::select(partyname, Q10_PTV, Q7) %>%   
+  na.omit() %>% 
+  .$Q7
+
+# We keep KE which contains PO, PSL and SLD parties. These 3 parties also lack values in Q7.
+
+# party
+
+
+# Create the Poland EES 2019 SDM # ====================================================================
+
+EES2019_pl_stack <- 
+  expand_grid(respid, party) %>% 
+  mutate(countrycode=EES2019_pl$countrycode %>% unique,
+         stack = paste0(respid, '-', party)) %>%
+  dplyr::select(countrycode, respid, party, stack)
+
+# Final plausibility check # ====================================================================
+
+# unique(EES2019_pl_stack$countrycode)
+# correct country code
+
+# unique(EES2019_pl$respid) %>% length()
+# unique(EES2019_pl_stack$respid) %>% length()
+# number of unique respondents IDs in both original data and SDM match
+
+# dim(EES2019_pl_stack)
+# 5000 by 4 data frame as expected (5 parties (PIS, Kukiz,
+# Wiosna, Razem and KE) x 1000 respondents)
+
+# Clean the environment # ==============================================================================
+
+rm(list=ls(pattern='_pl$|_crit$'))  
+rm(list = c('respid', 'party'))

--- a/Scripts/country_spec_scripts/EES2019_se_stack.R
+++ b/Scripts/country_spec_scripts/EES2019_se_stack.R
@@ -1,0 +1,93 @@
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Title: Script for Stacking Observations (EES 2019 Voter Study, Sweden Sample) 
+# Author: J.Leiser
+# last update: 2021-08-09
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# countrycode = 1752
+# countryshort = 'SE'
+
+# Keep the EES 2019 Sweden sample # ===================================================================
+EES2019_se <- 
+  EES2019 %>% 
+  filter(countrycode==1752)
+
+# Filter the codebook and EP elections data # ==========================================================
+
+EP2019_se <- 
+  EP2019 %>% 
+  filter(countryshort=='SE')
+
+
+EES2019_cdbk_se <- 
+  EES2019_cdbk %>% 
+  filter(countryshort=='SE')
+
+# Get the respondent ID codes # ========================================================================
+
+respid <- 
+  EES2019_se$respid %>% 
+  as.numeric()
+
+class(respid) #check class
+
+# Choose the relevant parties # ========================================================================
+
+
+# Check the parties about which we have the PTV variable # - - - - - - - - - - - - - - - - - - - - - - -
+
+ptv_crit <-
+  EES2019_cdbk_se %>% 
+  dplyr::select(partyname, Q10_PTV) 
+
+# ptv_crit
+# 8 parties
+# parties = S, M, MP, L, C, SD, KD, VP
+
+
+# Check the vote shares of parties that obtained at least one seat in the EP # - - - - - - - - - - - - -
+
+votes_crit <- 
+  EP2019_se %>% 
+  filter(party_name!='Other parties') 
+
+# votes_crit
+# 9 parties
+# parties = V (= VP from above), S, C, L, M, KD, MP, SD, FI
+
+# from the 8 parties with a PTV variable, all 8 obtained a seat in EP election
+# only keep those 8
+
+# Select the relevant parties # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
+party <- 
+  EES2019_cdbk_se %>% 
+  dplyr::select(partyname, Q10_PTV, Q7) %>%   
+  na.omit() %>% 
+  .$Q7
+
+# party
+
+# Create the Sweden EES 2019 SDM # ====================================================================
+
+EES2019_se_stack <- 
+  expand_grid(respid, party) %>% 
+  mutate(countrycode=EES2019_se$countrycode %>% unique,
+         stack = paste0(respid, '-', party)) %>%
+  dplyr::select(countrycode, respid, party, stack)
+
+# Final plausibility check # ====================================================================
+
+# unique(EES2019_se_stack$countrycode)
+# correct country code
+
+# unique(EES2019_se$respid) %>% length()
+# unique(EES2019_se_stack$respid) %>% length()
+# number of unique respondents IDs in both original data and SDM match
+
+# dim(EES2019_se_stack)
+# 8000 by 4 data frame as expected (8 parties x 1000 respondents)
+
+# Clean the environment # ==============================================================================
+
+rm(list=ls(pattern='_se$|_crit$'))  
+rm(list = c('respid', 'party'))

--- a/Scripts/country_spec_scripts/EES2019_sk_stack.R
+++ b/Scripts/country_spec_scripts/EES2019_sk_stack.R
@@ -1,0 +1,96 @@
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Title: Script for Stacking Observations (EES 2019 Voter Study, Slovakia Sample) 
+# Author: J.Leiser
+# last update: 2021-08-09
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# countrycode = 1703
+# countryshort = 'SK'
+
+# Keep the EES 2019 Slovakia sample # ===================================================================
+EES2019_sk <- 
+  EES2019 %>% 
+  filter(countrycode==1703)
+
+
+# Filter the codebook and EP elections data # ==========================================================
+
+EP2019_sk <- 
+  EP2019 %>% 
+  filter(countryshort=='SK')
+
+
+EES2019_cdbk_sk <- 
+  EES2019_cdbk %>% 
+  filter(countryshort=='SK')
+
+# Get the respondent ID codes # ========================================================================
+
+respid <- 
+  EES2019_sk$respid %>% 
+  as.numeric()
+
+class(respid) #check class
+
+# Choose the relevant parties # ========================================================================
+
+
+# Check the parties about which we have the PTV variable # - - - - - - - - - - - - - - - - - - - - - - -
+
+ptv_crit <-
+  EES2019_cdbk_sk %>% 
+  dplyr::select(partyname, Q10_PTV) 
+
+# ptv_crit
+# 9 parties
+# parties = KDH, LSNS, Sme rodina, Smer-SD, SaS, OL'aNo, PS + SPOLU, SNS,
+# Most-Hid
+
+
+# Check the vote shares of parties that obtained at least one seat in the EP # - - - - - - - - - - - - -
+
+votes_crit <- 
+  EP2019_sk %>% 
+  filter(party_name!='Other parties') 
+
+# votes_crit
+# 12 parties
+# parties = KDH, SaS, SNS, SMER-SD, SMK-MPK, OL'aNO + NOVA, MOST-HID
+# LSNS, Sme Rodina, PS + SPOLU, KU, KDZP
+
+# from the 9 parties with a PTV variable, all 9 obtained a seat in EP election
+# only keep those 9
+
+# Select the relevant parties # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
+party <- 
+  EES2019_cdbk_sk %>% 
+  dplyr::select(partyname, Q10_PTV, Q7) %>%   
+  na.omit() %>% 
+  .$Q7
+
+# party
+
+# Create the Slovakia EES 2019 SDM # ====================================================================
+
+EES2019_sk_stack <- 
+  expand_grid(respid, party) %>% 
+  mutate(countrycode=EES2019_sk$countrycode %>% unique,
+         stack = paste0(respid, '-', party)) %>%
+  dplyr::select(countrycode, respid, party, stack)
+
+# Final plausibility check # ====================================================================
+
+# unique(EES2019_sk_stack$countrycode)
+# correct country code
+
+# unique(EES2019_sk$respid) %>% length()
+# unique(EES2019_sk_stack$respid) %>% length()
+# number of unique respondents IDs in both original data and SDM match
+
+# dim(EES2019_sk_stack)
+# 9000 by 4 data frame as expected (9 parties x 1000 respondents)
+
+# Clean the environment # ==============================================================================
+
+rm(list=ls(pattern='_sk$|_crit$'))  
+rm(list = c('respid', 'party'))


### PR DESCRIPTION
Finished SDM scripts for all countries except for Poland.

UPDATE: 
- Poland issue below has been "fixed" as the single parties did not have vote choice variable (Q7) but the overall coalition did. So only the coalition (KE) is included. 
- For all countries: If a party was in a coalition during the EP election with other parties, I considered the EP seat criterion fulfilled if the coalition won a seat. Is this the correct application of the 2nd criterion?

Original issue:
The issue with Poland is, that there is a party/alliance for the EP election which consists of several other parties and in the codebook data we have both the "single" parties and their alliance, but for the EP dataset we only have data on the alliance. See the screenshots below
![PQ1](https://user-images.githubusercontent.com/87976159/128700702-5b39980e-e684-4494-8ce0-5b613acb5c0c.PNG)
From the codebook: data (PTV variable) is available on both the coalition and the constituent parties

![PQ2](https://user-images.githubusercontent.com/87976159/128701293-39cade6b-2e9c-4ae9-add0-926053d3995b.PNG)
From the EP data: only information on the overall coaltion is available

So, my question is: how we are supposed to deal with this situation to build the SDM? Do we include the alliance as a separate party or drop the alliance and only keep the single parties? Do we assume that the constituent parties have won a EP seat for our selection criterion if the overall alliance has won seats?