### PR TITLE
SDM Scripts for Austria(at), France(fr), Ireland(ie), Latvia(lv), Portugal(pt), Romania(ro), Slovenia(si)

### DIFF
--- a/Scripts/country_spec_scripts/EES2019_at_stack.R
+++ b/Scripts/country_spec_scripts/EES2019_at_stack.R
@@ -1,0 +1,78 @@
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Title: Script for Stacking Observations (EES 2019 Voter Study, Austrian Sample) 
+# Author: G.Carteny, Matthias Körnig(Ger529)
+# last update: 2021-08-12
+# Based on the template from the Italy stack. Just countrycode and names exchanged
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+# Keep the EES 2019 austrian sample # ===================================================================
+
+EES2019_at <- 
+  EES2019 %>% 
+  filter(countrycode==1040)
+
+
+# Filter the codebook and EP elections data # ==========================================================
+
+EP2019_at <- 
+  EP2019 %>% 
+  filter(countryshort=='AT')
+
+
+EES2019_cdbk_at <- 
+  EES2019_cdbk %>% 
+  filter(countryshort=='AT')
+
+
+# Get the respondent ID codes # ========================================================================
+
+respid <- 
+  EES2019_at$respid %>% 
+  as.numeric()
+
+# Choose the relevant parties # ========================================================================
+
+
+# Check the parties about which we have the PTV variable # - - - - - - - - - - - - - - - - - - - - - - -
+
+ptv_crit <-
+  EES2019_cdbk_at %>% 
+  dplyr::select(partyname, Q10_PTV) 
+
+  #ptv_crit: 6 parties
+  #parties: ÖVP, SPÖ, NEOS, Grüne, FPÖ, Jetzt
+
+# Check the vote shares of parties that obtained at least one seat in the EP # - - - - - - - - - - - - -
+
+votes_crit <- 
+  EP2019_at %>% 
+  filter(party_name!='Other parties') 
+
+  #votes_crit: 6 parties
+  #parties: SPÖ, ÖVP, FPÖ, Grüne, NEOS, Jetzt
+  #all parties with PTV variable obtained a seat in the EP. Thus, all 6 parties going into the selection
+
+# Select the relevant parties # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
+party <- 
+  EES2019_cdbk_at %>% 
+  dplyr::select(partyname, Q10_PTV, Q7) %>%   
+  na.omit() %>% 
+  .$Q7
+
+
+# Create the Austrian EES 2019 SDM # ====================================================================
+
+EES2019_at_stack <- 
+  expand_grid(respid, party) %>% 
+  mutate(countrycode=EES2019_at$countrycode %>% unique,
+         stack = paste0(respid, '-', party)) %>%
+  dplyr::select(countrycode, respid, party, stack)
+
+  #checking plausibility of the stack
+  #sapply(EES2019_at_stack, function(x) length(unique(x)))
+
+# Clean the environment # ==============================================================================
+
+rm(list=ls(pattern='_at$|_crit$'))  
+rm(list = c('respid', 'party'))

--- a/Scripts/country_spec_scripts/EES2019_fr_stack.R
+++ b/Scripts/country_spec_scripts/EES2019_fr_stack.R
@@ -1,0 +1,80 @@
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Title: Script for Stacking Observations (EES 2019 Voter Study, French Sample) 
+# Author: G.Carteny, Matthias Körnig(Ger529)
+# last update: 2021-08-12
+# Based on the template from the Italy stack. Just countrycode and names exchanged
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+# Keep the EES 2019 french sample # ===================================================================
+
+EES2019_fr <- 
+  EES2019 %>% 
+  filter(countrycode==1250)
+
+
+# Filter the codebook and EP elections data # ==========================================================
+
+EP2019_fr <- 
+  EP2019 %>% 
+  filter(countryshort=='FR')
+
+
+EES2019_cdbk_fr <- 
+  EES2019_cdbk %>% 
+  filter(countryshort=='FR')
+
+
+# Get the respondent ID codes # ========================================================================
+
+respid <- 
+  EES2019_fr$respid %>% 
+  as.numeric()
+
+# Choose the relevant parties # ========================================================================
+
+
+# Check the parties about which we have the PTV variable # - - - - - - - - - - - - - - - - - - - - - - -
+
+ptv_crit <-
+  EES2019_cdbk_fr %>% 
+  dplyr::select(partyname, Q10_PTV) 
+
+  #ptv_crit: 7 parties and coalitions
+  #parties: LR, PS, RN, EELV, LFI, Generations.s, LRM
+
+# Check the vote shares of parties that obtained at least one seat in the EP # - - - - - - - - - - - - -
+
+votes_crit <- 
+  EP2019_fr %>% 
+  filter(party_name!='Other parties') 
+
+  #votes_crit: 10 parties and coalitions
+  #parties: FI, Coal, (PS+RDG+PP+N), EELV, LR, RN, DLF+CNIP, Coal, (LREM+Modem+MRSL), PCF, UDI, Generation.s
+  #note: shortname differnces between ptv_crit and votes_crit: LFI is FI, LRM is LREM
+  #note: PS and LRM only received a seat within a coalition with other parties
+  #all parties with PTV variable obtained a seat in the EP. Thus, all 7 parties going into the selection
+
+# Select the relevant parties # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
+party <- 
+  EES2019_cdbk_fr %>% 
+  dplyr::select(partyname, Q10_PTV, Q7) %>%   
+  na.omit() %>% 
+  .$Q7
+
+
+# Create the French EES 2019 SDM # ====================================================================
+
+EES2019_fr_stack <- 
+  expand_grid(respid, party) %>% 
+  mutate(countrycode=EES2019_fr$countrycode %>% unique,
+         stack = paste0(respid, '-', party)) %>%
+  dplyr::select(countrycode, respid, party, stack)
+
+#checking plausibility of the stack
+#sapply(EES2019_fr_stack, function(x) length(unique(x)))
+
+# Clean the environment # ==============================================================================
+
+rm(list=ls(pattern='_fr$|_crit$'))  
+rm(list = c('respid', 'party'))

--- a/Scripts/country_spec_scripts/EES2019_ie_stack.R
+++ b/Scripts/country_spec_scripts/EES2019_ie_stack.R
@@ -1,0 +1,82 @@
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Title: Script for Stacking Observations (EES 2019 Voter Study, Ireland Sample) 
+# Author: M.Koernig, G.Carteny
+# last update: 2021-08-12
+# Based on the template from the Italy stack. Just countrycode and names exchanged
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+# Keep the EES 2019 ireland sample # ===================================================================
+
+EES2019_ie <- 
+  EES2019 %>% 
+  filter(countrycode==1372)
+
+
+# Filter the codebook and EP elections data # ==========================================================
+
+EP2019_ie <- 
+  EP2019 %>% 
+  filter(countryshort=='IE')
+
+
+EES2019_cdbk_ie <- 
+  EES2019_cdbk %>% 
+  filter(countryshort=='IE')
+
+
+# Get the respondent ID codes # ========================================================================
+
+respid <- 
+  EES2019_ie$respid %>% 
+  as.numeric()
+
+# Choose the relevant parties # ========================================================================
+
+
+# Check the parties about which we have the PTV variable # - - - - - - - - - - - - - - - - - - - - - - -
+
+ptv_crit <-
+  EES2019_cdbk_ie %>% 
+  dplyr::select(partyname, Q10_PTV) 
+
+#ptv_crit: 6 parties
+#parties: FG, LAB, FF, GP, SF, Solidarity
+
+# Check the vote shares of parties that obtained at least one seat in the EP # - - - - - - - - - - - - -
+
+votes_crit <- 
+  EP2019_ie %>% 
+  filter(party_name!='Other parties') 
+
+#votes_crit: 8 parties
+#parties: FF, FG, LAB, GP, SF, Ind., SD, I4C
+#The party Solidarity shows a PTV variable, but did not obtain a seat in the EP
+#All other parties with PTV variable obtained at least one seat in the EP
+#Thus, the party Solidarity needs to be filtered out
+
+# Select the relevant parties # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
+party <- 
+  EES2019_cdbk_ie %>% 
+  dplyr::select(partyname, Q10_PTV, Q7) %>%   
+  na.omit() %>%
+  filter(partyname!='Solidarity - People Before Profit/') %>%
+  .$Q7
+
+#Only 5 parties remain in the selection without Solidarity
+
+# Create the Ireland EES 2019 SDM # ====================================================================
+
+EES2019_ie_stack <- 
+  expand_grid(respid, party) %>% 
+  mutate(countrycode=EES2019_ie$countrycode %>% unique,
+         stack = paste0(respid, '-', party)) %>%
+  dplyr::select(countrycode, respid, party, stack)
+
+  #checking plausibility of the stack
+  #sapply(EES2019_ie_stack, function(x) length(unique(x)))
+
+# Clean the environment # ==============================================================================
+
+rm(list=ls(pattern='_ie$|_crit$'))  
+rm(list = c('respid', 'party'))

--- a/Scripts/country_spec_scripts/EES2019_lv_stack.R
+++ b/Scripts/country_spec_scripts/EES2019_lv_stack.R
@@ -1,0 +1,78 @@
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Title: Script for Stacking Observations (EES 2019 Voter Study, Latvian Sample) 
+# Author: G.Carteny, M.Koernig
+# last update: 2021-08-12
+# Based on the template from the Italy stack. Just countrycode and names exchanged
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+# Keep the EES 2019 latvian sample # ===================================================================
+
+EES2019_lv <- 
+  EES2019 %>% 
+  filter(countrycode==1428)
+
+
+# Filter the codebook and EP elections data # ==========================================================
+
+EP2019_lv <- 
+  EP2019 %>% 
+  filter(countryshort=='LV')
+
+
+EES2019_cdbk_lv <- 
+  EES2019_cdbk %>% 
+  filter(countryshort=='LV')
+
+
+# Get the respondent ID codes # ========================================================================
+
+respid <- 
+  EES2019_lv$respid %>% 
+  as.numeric()
+
+# Choose the relevant parties # ========================================================================
+
+
+# Check the parties about which we have the PTV variable # - - - - - - - - - - - - - - - - - - - - - - -
+
+ptv_crit <-
+  EES2019_cdbk_lv %>% 
+  dplyr::select(partyname, Q10_PTV) 
+
+#ptv_crit: 7 parties and coalitions
+#parties and coalitions: Coal. NA, JKP, Coal. AP!, KPV LV, Saskana SDP, Coal. ZZS, JV
+#note: here not only the parties but also coalitions are listed
+
+# Check the vote shares of parties that obtained at least one seat in the EP # - - - - - - - - - - - - -
+
+votes_crit <- 
+  EP2019_lv %>% 
+  filter(party_name!='Other parties')
+
+#votes_crit: 16 parties and coalitions
+#all parties/coalitions with PTV variable obtained at least on eseat in the EP
+
+# Select the relevant parties # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
+party <- 
+  EES2019_cdbk_lv %>% 
+  dplyr::select(partyname, Q10_PTV, Q7) %>%   
+  na.omit() %>% 
+  .$Q7
+
+
+# Create the Latvian EES 2019 SDM # ====================================================================
+
+EES2019_lv_stack <- 
+  expand_grid(respid, party) %>% 
+  mutate(countrycode=EES2019_lv$countrycode %>% unique,
+         stack = paste0(respid, '-', party)) %>%
+  dplyr::select(countrycode, respid, party, stack)
+
+#checking plausibility of the stack
+#sapply(EES2019_lv_stack, function(x) length(unique(x)))
+
+# Clean the environment # ==============================================================================
+
+rm(list=ls(pattern='_lv$|_crit$'))  
+rm(list = c('respid', 'party'))

--- a/Scripts/country_spec_scripts/EES2019_pt_stack.R
+++ b/Scripts/country_spec_scripts/EES2019_pt_stack.R
@@ -1,0 +1,78 @@
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Title: Script for Stacking Observations (EES 2019 Voter Study, Portugal Sample) 
+# Author: G.Carteny, M.Koernig
+# last update: 2021-08-12
+# Based on the template from the Italy stack. Just countrycode and names exchanged
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+# Keep the EES 2019 portugal sample # ===================================================================
+
+EES2019_pt <- 
+  EES2019 %>% 
+  filter(countrycode==1620)
+
+
+# Filter the codebook and EP elections data # ==========================================================
+
+EP2019_pt <- 
+  EP2019 %>% 
+  filter(countryshort=='PT')
+
+
+EES2019_cdbk_pt <- 
+  EES2019_cdbk %>% 
+  filter(countryshort=='PT')
+
+
+# Get the respondent ID codes # ========================================================================
+
+respid <- 
+  EES2019_pt$respid %>% 
+  as.numeric()
+
+# Choose the relevant parties # ========================================================================
+
+
+# Check the parties about which we have the PTV variable # - - - - - - - - - - - - - - - - - - - - - - -
+
+ptv_crit <-
+  EES2019_cdbk_pt %>% 
+  dplyr::select(partyname, Q10_PTV) 
+
+#ptv_crit: 6 parties and coalitions
+#parties and coalitions: PSD, CDS-PP, PS, CDU (coalition), BE, PAN
+
+# Check the vote shares of parties that obtained at least one seat in the EP # - - - - - - - - - - - - -
+
+votes_crit <- 
+  EP2019_pt %>% 
+  filter(party_name!='Other parties') 
+
+#votes_crit: 7 parties and coalitions
+#parties and coalitions: BE, CDU, PS, PSD CDS-PP, PAN, A
+#all parties/coalitions with PTV variable obtained at least one seat in the EP
+
+# Select the relevant parties # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
+party <- 
+  EES2019_cdbk_pt %>% 
+  dplyr::select(partyname, Q10_PTV, Q7) %>%   
+  na.omit() %>% 
+  .$Q7
+
+
+# Create the Portugal EES 2019 SDM # ====================================================================
+
+EES2019_pt_stack <- 
+  expand_grid(respid, party) %>% 
+  mutate(countrycode=EES2019_pt$countrycode %>% unique,
+         stack = paste0(respid, '-', party)) %>%
+  dplyr::select(countrycode, respid, party, stack)
+
+#checking plausibility of the stack
+#sapply(EES2019_pt_stack, function(x) length(unique(x)))
+
+# Clean the environment # ==============================================================================
+
+rm(list=ls(pattern='_pt$|_crit$'))  
+rm(list = c('respid', 'party'))

--- a/Scripts/country_spec_scripts/EES2019_ro_stack.R
+++ b/Scripts/country_spec_scripts/EES2019_ro_stack.R
@@ -1,0 +1,84 @@
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Title: Script for Stacking Observations (EES 2019 Voter Study, Romanian Sample) 
+# Author: G.Carteny, M.Koernig
+# last update: 2021-08-12
+# Based on the template from the Italy stack. Just countrycode and names exchanged
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+# Keep the EES 2019 romanian sample # ===================================================================
+
+EES2019_ro <- 
+  EES2019 %>% 
+  filter(countrycode==1642)
+
+
+# Filter the codebook and EP elections data # ==========================================================
+
+EP2019_ro <- 
+  EP2019 %>% 
+  filter(countryshort=='RO')
+
+
+EES2019_cdbk_ro <- 
+  EES2019_cdbk %>% 
+  filter(countryshort=='RO')
+
+
+# Get the respondent ID codes # ========================================================================
+
+respid <- 
+  EES2019_ro$respid %>% 
+  as.numeric()
+
+# Choose the relevant parties # ========================================================================
+
+
+# Check the parties about which we have the PTV variable # - - - - - - - - - - - - - - - - - - - - - - -
+
+ptv_crit <-
+  EES2019_cdbk_ro %>% 
+  dplyr::select(partyname, Q10_PTV) 
+
+#ptv_crit: 9 parties and coalitions
+#parties/coalitions: PSD, USR, ALDE, PPR, PNL, UDMR, PMP, +Plus, Alliance (coalition)
+#note: 2 of the 9 parties (USR, +Plus) form the Aliance Coalition
+
+# Check the vote shares of parties that obtained at least one seat in the EP # - - - - - - - - - - - - -
+
+votes_crit <- 
+  EP2019_ro %>% 
+  filter(party_name!='Other parties') 
+
+#votes_crit: 7 parties and coalitions
+#party/coalition: PSD, ALDE, PNL, UDMR, PMP, Pro Romania, Coal. Alliance
+#note: Pro Romania is PPR in ptv_crit
+
+#all parties with PTV variable obtained at least one seat in the EP. However the two of them
+#(USR, +Plus) are listed uniquely and in the coalition
+
+# Select the relevant parties # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
+party <- 
+  EES2019_cdbk_ro %>% 
+  dplyr::select(partyname, Q10_PTV, Q7) %>%   
+  na.omit() %>% 
+  .$Q7
+
+#Only the coalition Alliance of USR and +Plus listed, not USR, +Plus individually
+#Thus, only 7 parties/coalitions listed
+
+# Create the Romanian EES 2019 SDM # ====================================================================
+
+EES2019_ro_stack <- 
+  expand_grid(respid, party) %>% 
+  mutate(countrycode=EES2019_ro$countrycode %>% unique,
+         stack = paste0(respid, '-', party)) %>%
+  dplyr::select(countrycode, respid, party, stack)
+
+#checking plausibility of the stack
+#sapply(EES2019_ro_stack, function(x) length(unique(x)))
+
+# Clean the environment # ==============================================================================
+
+rm(list=ls(pattern='_ro$|_crit$'))  
+rm(list = c('respid', 'party'))

--- a/Scripts/country_spec_scripts/EES2019_si_stack.R
+++ b/Scripts/country_spec_scripts/EES2019_si_stack.R
@@ -1,0 +1,78 @@
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Title: Script for Stacking Observations (EES 2019 Voter Study, Slovenian Sample) 
+# Author: G.Carteny, M.Koernig
+# last update: 2021-08-12
+# Based on the template from the Italy stack. Just countrycode and names exchanged
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+# Keep the EES 2019 slovenian sample # ===================================================================
+
+EES2019_si <- 
+  EES2019 %>% 
+  filter(countrycode==1705)
+
+
+# Filter the codebook and EP elections data # ==========================================================
+
+EP2019_si <- 
+  EP2019 %>% 
+  filter(countryshort=='SI')
+
+
+EES2019_cdbk_si <- 
+  EES2019_cdbk %>% 
+  filter(countryshort=='SI')
+
+
+# Get the respondent ID codes # ========================================================================
+
+respid <- 
+  EES2019_si$respid %>% 
+  as.numeric()
+
+# Choose the relevant parties # ========================================================================
+
+
+# Check the parties about which we have the PTV variable # - - - - - - - - - - - - - - - - - - - - - - -
+
+ptv_crit <-
+  EES2019_cdbk_si %>% 
+  dplyr::select(partyname, Q10_PTV) 
+
+#ptv_crit: 9 parties and coalitions
+#parties/coalitions: SDS in SLS, LMŠ, SD, NSi, Levica, SNS, SMC, SAB, DESUS 
+
+# Check the vote shares of parties that obtained at least one seat in the EP # - - - - - - - - - - - - -
+
+votes_crit <- 
+  EP2019_si %>% 
+  filter(party_name!='Other parties') 
+
+#votes_crit: 14 parties and coalitions
+#all parties/coalitions with PTV variable obtained at least one seat in the EP
+
+# Select the relevant parties # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
+party <- 
+  EES2019_cdbk_si %>% 
+  dplyr::select(partyname, Q10_PTV, Q7) %>%   
+  na.omit() %>% 
+  .$Q7
+
+#party: 9 parties and coalitions
+
+# Create the Slovenian EES 2019 SDM # ====================================================================
+
+EES2019_si_stack <- 
+  expand_grid(respid, party) %>% 
+  mutate(countrycode=EES2019_si$countrycode %>% unique,
+         stack = paste0(respid, '-', party)) %>%
+  dplyr::select(countrycode, respid, party, stack)
+
+#checking plausibility of the stack
+#sapply(EES2019_si_stack, function(x) length(unique(x)))
+
+# Clean the environment # ==============================================================================
+
+rm(list=ls(pattern='_si$|_crit$'))  
+rm(list = c('respid', 'party'))


### PR DESCRIPTION
For nearly all SDM Scripts all parties with PTV variables also obtained at least one seat in the EP.

Only for the case of Ireland one party with a PTV variable didn't receive a seat in the EP, thus, had to be filtered out.