### PR TITLE
Adding seats criteria to scripts for Denmark, Estonia, Germany, Luxembourg, Malta and UK

### DIFF
--- a/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_de.R
+++ b/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_de.R
@@ -1,0 +1,60 @@
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Title: EES2019 enhanced codebook (Germany sample)
+# Author: W. Haeussling
+# last update: 2021-08-27
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+
+# Select the German codebook and EP results # =========================================================
+
+
+EES2019_cdbk_de <-
+  EES2019_cdbk %>%
+  filter(countryshort=='DE')
+
+EP2019_de <-
+  EP2019 %>%
+  filter(countryshort=='DE')
+
+
+# Create a common variable for merging datasets # ======================================================
+
+# Print the two country-specific auxiliary dataframes for coding purposes, 
+# but mute them once the coding process is completed.
+
+# EES2019_cdbk_de %>%
+#   dplyr::select(partyname, partyname_eng, Q7)
+# 
+# EP2019_de %>%
+#   dplyr::select(partyname, partyname_eng, partyid)
+
+EP2019_de %<>%
+  filter(partyid!='DE90') %>% 
+  mutate(Q7 = case_when(partyid=='DE01' ~ as.integer(801),
+                        partyid=='DE02' ~ as.integer(802),
+                        partyid=='DE03' ~ as.integer(803), 
+                        partyid=='DE04' ~ as.integer(804),
+                        partyid=='DE05' ~ as.integer(807),
+                        partyid=='DE06' ~ as.integer(805),
+                        partyid=='DE08' ~ as.integer(806),
+                        T~NA_integer_))
+
+EES2019_de_enhcdbk <- 
+  left_join(EES2019_cdbk_de,
+            EP2019_de %>% dplyr::select(Q7, votesh, seats),
+            by = 'Q7')
+
+#The parties 'FREIE WÄHLER', 'Tierschutzpartei', 'FAMILIE', 'ÖDP', 'Die Partei' 
+#and 'VOLT' (by partyname in EP2019_de) all gained a seat in the election.
+#Because they don't have a party specific code, they are not going to appear in 
+#EES2019_de_enhcdbk.
+
+
+# Check the new dataset 
+
+#EES2019_de_enhcdbk %>% 
+#   dplyr::select(partyname, partyname_eng, Q7, votesh, seats)
+
+# Clean the environment # ==============================================================================
+
+rm(list=ls(pattern='_de$')) 

--- a/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_dk.R
+++ b/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_dk.R
@@ -39,25 +39,24 @@ EP2019_dk %<>%
                         partyid=='DK07' ~ as.integer(703),
                         partyid=='DK08' ~ as.integer(702),
                         partyid=='DK09' ~ as.integer(706),
-                        partyid=='DK10' ~ as.integer(000),
+                        partyid=='DK10' ~ as.integer(1),
                         T~NA_integer_))
 
 #EES_cdbk_dk includes the party 'Kristendemokraterne' which isn't 
 #included in EP2019_dk. This party has the Q7-value NA.
 #Vice versa EP2019_dk includes the Party 'Alternativet' which isn't included in
-#EES_cdbk_dk.
-#'Alternativet'-Q7_data is changed to 000 in the EP_2019_dk column 
+#EES_cdbk_dk and therefore should have the Q7-value NA.
+#'Alternativet'-Q7_data is changed to 1 in the EP_2019_dk column 
 #Q7 so that in the left join no data is mixed. 
 
-#I will change EES2019_dk_enhcdbk manually for 'Alternativet' so that the 
-#votesh and seats data are included for 'Alternativet'.
+#I will change EES2019_dk_enhcdbk and EP2019_dk manually so that there are no 
+#'data mix-ups'.
 
 EES2019_dk_enhcdbk <- 
   left_join(EES2019_cdbk_dk,
             EP2019_dk %>% dplyr::select(Q7, votesh, seats),
-            by = 'Q7') %>%
-  add_row(countryshort=as.character('DK'), countrycode=1208, partyname='Alternativet', 
-          votesh=0.0337, seats=0 )
+            by = 'Q7') 
+EP2019_dk[10,7] <- NA
 
 
 

--- a/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_dk.R
+++ b/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_dk.R
@@ -1,0 +1,72 @@
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Title: EES2019 enhanced codebook (Denmark sample)
+# Author: W. Haeussling
+# last update: 2021-08-27
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+
+# Select the danish codebook and EP results # =========================================================
+
+
+EES2019_cdbk_dk <-
+  EES2019_cdbk %>%
+  filter(countryshort=='DK')
+
+EP2019_dk <-
+  EP2019 %>%
+  filter(countryshort=='DK')
+
+
+# Create a common variable for merging datasets # ======================================================
+
+# Print the two country-specific auxiliary dataframes for coding purposes, 
+# but mute them once the coding process is completed.
+
+# EES2019_cdbk_dk %>%
+#   dplyr::select(partyname, partyname_eng, Q7)
+# 
+# EP2019_dk %>%
+#   dplyr::select(partyname, partyname_eng, partyid)
+
+EP2019_dk %<>%
+  filter(partyid!='DK90') %>% 
+  mutate(Q7 = case_when(partyid=='DK01' ~ as.integer(701),
+                        partyid=='DK02' ~ as.integer(704),
+                        partyid=='DK03' ~ as.integer(707), 
+                        partyid=='DK04' ~ as.integer(705),
+                        partyid=='DK05' ~ as.integer(708),
+                        partyid=='DK06' ~ as.integer(709),
+                        partyid=='DK07' ~ as.integer(703),
+                        partyid=='DK08' ~ as.integer(702),
+                        partyid=='DK09' ~ as.integer(706),
+                        partyid=='DK10' ~ as.integer(000),
+                        T~NA_integer_))
+
+#EES_cdbk_dk includes the party 'Kristendemokraterne' which isn't 
+#included in EP2019_dk. This party has the Q7-value NA.
+#Vice versa EP2019_dk includes the Party 'Alternativet' which isn't included in
+#EES_cdbk_dk.
+#'Alternativet'-Q7_data is changed to 000 in the EP_2019_dk column 
+#Q7 so that in the left join no data is mixed. 
+
+#I will change EES2019_dk_enhcdbk manually for 'Alternativet' so that the 
+#votesh and seats data are included for 'Alternativet'.
+
+EES2019_dk_enhcdbk <- 
+  left_join(EES2019_cdbk_dk,
+            EP2019_dk %>% dplyr::select(Q7, votesh, seats),
+            by = 'Q7') %>%
+  add_row(countryshort=as.character('DK'), countrycode=1208, partyname='Alternativet', 
+          votesh=0.0337, seats=0 )
+
+
+
+
+# Check the new dataset 
+
+#EES2019_dk_enhcdbk %>% 
+#   dplyr::select(partyname, partyname_eng, Q7, votesh, seats)
+
+# Clean the environment # ==============================================================================
+
+rm(list=ls(pattern='_dk$')) 

--- a/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_ee.R
+++ b/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_ee.R
@@ -48,7 +48,7 @@ EES2019_ee_enhcdbk <-
 
 # Check the new dataset 
 
-#EES2019_dk_enhcdbk %>% 
+#EES2019_ee_enhcdbk %>% 
 #   dplyr::select(partyname, partyname_eng, Q7, votesh, seats)
 
 # Clean the environment # ==============================================================================

--- a/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_ee.R
+++ b/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_ee.R
@@ -1,0 +1,56 @@
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Title: EES2019 enhanced codebook (Estonia sample)
+# Author: W. Haeussling
+# last update: 2021-08-27
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+
+# Select the estonian codebook and EP results # =========================================================
+
+
+EES2019_cdbk_ee <-
+  EES2019_cdbk %>%
+  filter(countryshort=='EE')
+
+EP2019_ee <-
+  EP2019 %>%
+  filter(countryshort=='EE')
+
+
+# Create a common variable for merging datasets # ======================================================
+
+# Print the two country-specific auxiliary dataframes for coding purposes, 
+# but mute them once the coding process is completed.
+
+# EES2019_cdbk_ee %>%
+#   dplyr::select(partyname, partyname_eng, Q7)
+ 
+# EP2019_ee %>%
+#   dplyr::select(partyname, partyname_eng, partyid)
+
+EP2019_ee %<>%
+  filter(partyid!='EE90') %>% 
+  mutate(Q7 = case_when(partyid=='EE01' ~ as.integer(901),
+                        partyid=='EE02' ~ as.integer(902),
+                        partyid=='EE03' ~ as.integer(904), 
+                        partyid=='EE04' ~ as.integer(905),
+                        partyid=='EE05' ~ as.integer(907),
+                        partyid=='EE06' ~ as.integer(903),
+                        partyid=='EE07' ~ as.integer(906),
+                        partyid=='EE08' ~ as.integer(908),
+                        T~NA_integer_))
+
+EES2019_ee_enhcdbk <- 
+  left_join(EES2019_cdbk_ee,
+            EP2019_ee %>% dplyr::select(Q7, votesh, seats),
+            by = 'Q7') 
+
+
+# Check the new dataset 
+
+#EES2019_dk_enhcdbk %>% 
+#   dplyr::select(partyname, partyname_eng, Q7, votesh, seats)
+
+# Clean the environment # ==============================================================================
+
+rm(list=ls(pattern='_ee$')) 

--- a/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_lu.R
+++ b/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_lu.R
@@ -1,0 +1,66 @@
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Title: EES2019 enhanced codebook (Luxembourg sample)
+# Author: W. Haeussling
+# last update: 2021-08-27
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+
+# Select the Luxembourgian codebook and EP results # =========================================================
+
+
+EES2019_cdbk_lu <-
+  EES2019_cdbk %>%
+  filter(countryshort=='LU')
+
+EP2019_lu <-
+  EP2019 %>%
+  filter(countryshort=='LU')
+
+
+# Create a common variable for merging datasets # ======================================================
+
+# Print the two country-specific auxiliary dataframes for coding purposes, 
+# but mute them once the coding process is completed.
+
+# EES2019_cdbk_lu %>%
+#   dplyr::select(partyname, partyname_eng, Q7)
+# 
+# EP2019_lu %>%
+#   dplyr::select(partyname, partyname_eng, partyid)
+
+EP2019_lu %<>%
+  filter(partyid!='LU90') %>% 
+  mutate(Q7 = case_when(partyid=='LU01' ~ as.integer(1804),
+                        partyid=='LU02' ~ as.integer(1802),
+                        partyid=='LU03' ~ as.integer(1803), 
+                        partyid=='LU04' ~ as.integer(1805),
+                        partyid=='LU05' ~ as.integer(1801),
+                        partyid=='LU06' ~ as.integer(1806),
+                        partyid=='LU07' ~ as.integer(1807),
+                        partyid=='LU09' ~ as.integer(1808),
+                        partyid=='LU10' ~ as.integer(1809),
+                        T~NA_integer_))
+
+#LU08 is the party 'Kommunistesch Partei Letzebuerg'. This party is also in 
+#EES2019_lu but has no partycode there as well as another party. This will 
+#lead to a mix-up in the data through the function left_join.
+#I will therefore additionally adapt some values manually .
+
+EES2019_lu_enhcdbk <- 
+  left_join(EES2019_cdbk_lu,
+            EP2019_lu %>% dplyr::select(Q7, votesh, seats),
+            by = 'Q7') 
+EES2019_lu_enhcdbk [11, 20] <- NA
+EES2019_lu_enhcdbk [11, 21] <- NA
+
+
+
+
+# Check the new dataset 
+
+#EES2019_lu_enhcdbk %>% 
+#   dplyr::select(partyname, partyname_eng, Q7, votesh, seats)
+
+# Clean the environment # ==============================================================================
+
+rm(list=ls(pattern='_lu$')) 

--- a/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_mt.R
+++ b/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_mt.R
@@ -1,0 +1,54 @@
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Title: EES2019 enhanced codebook (Malta sample)
+# Author: W. Haeussling
+# last update: 2021-08-27
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+
+# Select the Maltese codebook and EP results # =========================================================
+
+
+EES2019_cdbk_mt <-
+  EES2019_cdbk %>%
+  filter(countryshort=='MT')
+
+EP2019_mt <-
+  EP2019 %>%
+  filter(countryshort=='MT')
+
+
+# Create a common variable for merging datasets # ======================================================
+
+# Print the two country-specific auxiliary dataframes for coding purposes, 
+# but mute them once the coding process is completed.
+
+# EES2019_cdbk_mt %>%
+#   dplyr::select(partyname, partyname_eng, Q7)
+# 
+# EP2019_mt %>%
+#   dplyr::select(partyname, partyname_eng, partyid)
+
+EP2019_mt %<>%
+  filter(partyid!='MT90') %>% 
+  mutate(Q7 = case_when(partyid=='MT01' ~ as.integer(1902),
+                        partyid=='MT02' ~ as.integer(1901),
+                        partyid=='MT03' ~ as.integer(1903), 
+                        partyid=='MT04' ~ as.integer(1904),
+                        T~NA_integer_))
+
+EES2019_mt_enhcdbk <- 
+  left_join(EES2019_cdbk_mt,
+            EP2019_mt %>% dplyr::select(Q7, votesh, seats),
+            by = 'Q7')
+
+
+
+
+# Check the new dataset 
+
+#EES2019_mt_enhcdbk %>% 
+#   dplyr::select(partyname, partyname_eng, Q7, votesh, seats)
+
+# Clean the environment # ==============================================================================
+
+rm(list=ls(pattern='_mt$')) 

--- a/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_uk.R
+++ b/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_uk.R
@@ -1,0 +1,64 @@
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Title: EES2019 enhanced codebook (United Kingdom sample)
+# Author: W.Haeussling
+# last update: 2021-08-27
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+
+# Select the United Kingdom codebook and EP results # =========================================================
+
+
+EES2019_cdbk_uk <-
+  EES2019_cdbk %>%
+  filter(countryshort=='UK')
+
+EP2019_uk <-
+  EP2019 %>%
+  filter(countryshort=='UK')
+
+
+# Create a common variable for merging datasets # ======================================================
+
+# Print the two country-specific auxiliary dataframes for coding purposes, 
+# but mute them once the coding process is completed.
+
+# EES2019_cdbk_uk %>%
+#   dplyr::select(partyname, partyname_eng, Q7)
+# 
+# EP2019_uk %>%
+#   dplyr::select(partyname, partyname_eng, partyid)
+
+EP2019_uk %<>%
+  filter(partyid!='UK90', partyid!='UK91') %>% 
+  mutate(Q7 = case_when(partyid=='UK01' ~ as.integer(2810),
+                        partyid=='UK02' ~ as.integer(2811),
+                        partyid=='UK03' ~ as.integer(2812), 
+                        partyid=='UK04' ~ as.integer(2813),
+                        partyid=='UK07' ~ as.integer(2801),
+                        partyid=='UK08' ~ as.integer(2802),
+                        partyid=='UK09' ~ as.integer(2806),
+                        partyid=='UK10' ~ as.integer(2805),
+                        partyid=='UK11' ~ as.integer(2809),
+                        partyid=='UK12' ~ as.integer(2803),
+                        partyid=='UK13' ~ as.integer(2804),
+                        partyid=='UK14' ~ as.integer(2808),
+                        partyid=='UK15' ~ as.integer(2807),
+                        T~NA_integer_))
+
+
+EES2019_uk_enhcdbk <- 
+  left_join(EES2019_cdbk_uk,
+            EP2019_uk %>% dplyr::select(Q7, votesh, seats),
+            by = 'Q7')
+
+#From those parties dropped by the left_join function one party, namely the 
+#'Alliance Party', received one seat, the other none.
+
+# Check the new dataset 
+
+# EES2019_uk_enhcdbk %>% 
+#   dplyr::select(partyname, partyname_eng, Q7, votesh, seats)
+
+# Clean the environment # ==============================================================================
+
+rm(list=ls(pattern='_uk$')) 

--- a/Scripts/country_spec_scripts/EES2019_de_stack.R
+++ b/Scripts/country_spec_scripts/EES2019_de_stack.R
@@ -1,7 +1,7 @@
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Title: Script for Stacking Observations (EES 2019 Voter Study, Germany Sample) 
 # Author: W.Haeussling
-# last update: 2021-08-08
+# last update: 2021-08-27
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 # Keep the EES 2019 Germany sample # ===================================================================
@@ -11,11 +11,11 @@ EES2019_de <-
   filter(countrycode==1276)
 
 
-# Filter the codebook and EP elections data # ==========================================================
+# Filter the codebook data # ==========================================================
 
-EP2019_de <- 
-  EP2019 %>% 
-  filter(countryshort=='DE')
+#EP2019_de <- 
+#  EP2019 %>% 
+#  filter(countryshort=='DE')
 
 
 EES2019_cdbk_de <- 
@@ -41,8 +41,9 @@ ptv_crit <-
 # Check the vote shares of parties that obtained at least one seat in the EP # - - - - - - - - - - - - -
 
 votes_crit <- 
-  EP2019_de %>% 
-  filter(partyname!='Other parties') 
+  EES2019_cdbk_de %>%
+  mutate(seats = case_when(seats==as.integer(0) ~ NA_integer_, T~seats)) %>% 
+  dplyr::select(partyname, votesh, seats) 
 
 # Select the relevant parties # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 

--- a/Scripts/country_spec_scripts/EES2019_dk_stack.R
+++ b/Scripts/country_spec_scripts/EES2019_dk_stack.R
@@ -1,7 +1,7 @@
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Title: Script for Stacking Observations (EES 2019 Voter Study, Denmark Sample) 
 # Author: W.Haeussling
-# last update: 2021-08-08
+# last update: 2021-08-27
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 # Keep the EES 2019 Denmark sample # ===================================================================
@@ -11,12 +11,11 @@ EES2019_dk <-
   filter(countrycode==1208)
 
 
-# Filter the codebook and EP elections data # ==========================================================
+# Filter the codebook data # ==========================================================
 
-EP2019_dk <- 
-  EP2019 %>% 
-  filter(countryshort=='DK')
-
+#EP2019_dk <- 
+#  EP2019 %>% 
+#  filter(countryshort=='DK')
 
 EES2019_cdbk_dk <- 
   EES2019_cdbk %>% 
@@ -41,8 +40,9 @@ ptv_crit <-
 # Check the vote shares of parties that obtained at least one seat in the EP # - - - - - - - - - - - - -
 
 votes_crit <- 
-  EP2019_dk %>% 
-  filter(partyname!='Other parties') 
+  EES2019_dk_enhcdbk %>% 
+  mutate(seats = case_when(seats==as.integer(0) ~ NA_integer_, T~seats)) %>% 
+  dplyr::select(partyname, votesh, seats)
 
 # Select the relevant parties # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 

--- a/Scripts/country_spec_scripts/EES2019_dk_stack.R
+++ b/Scripts/country_spec_scripts/EES2019_dk_stack.R
@@ -21,7 +21,6 @@ EES2019_cdbk_dk <-
   EES2019_cdbk %>% 
   filter(countryshort=='DK')
 
-
 # Get the respondent ID codes # ========================================================================
 
 respid <- 
@@ -40,9 +39,10 @@ ptv_crit <-
 # Check the vote shares of parties that obtained at least one seat in the EP # - - - - - - - - - - - - -
 
 votes_crit <- 
-  EES2019_dk_enhcdbk %>% 
+  EES2019_cdbk_dk %>% 
   mutate(seats = case_when(seats==as.integer(0) ~ NA_integer_, T~seats)) %>% 
   dplyr::select(partyname, votesh, seats)
+
 
 # Select the relevant parties # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 

--- a/Scripts/country_spec_scripts/EES2019_ee_stack.R
+++ b/Scripts/country_spec_scripts/EES2019_ee_stack.R
@@ -11,17 +11,17 @@ EES2019_ee <-
   filter(countrycode==1233)
 
 
-# Filter the codebook and EP elections data # ==========================================================
+# Filter the codebook data # ==========================================================
 
-EP2019_ee <- 
-  EP2019 %>% 
-  filter(countryshort=='EE')
-
+#EP2019_ee <- 
+#  EP2019 %>% 
+#  filter(countryshort=='EE')
 
 EES2019_cdbk_ee <- 
   EES2019_cdbk %>% 
   filter(countryshort=='EE')
 
+#EES2019_cdbk is from EESstacked\Scripts\aux_data_scripts\EES2019_cdbk.R
 
 # Get the respondent ID codes # ========================================================================
 
@@ -41,8 +41,12 @@ ptv_crit <-
 # Check the vote shares of parties that obtained at least one seat in the EP # - - - - - - - - - - - - -
 
 votes_crit <- 
-  EP2019_ee %>% 
-  filter(partyname!='Other parties') 
+  EES2019_ee_enhcdbk %>% 
+  mutate(seats = case_when(seats==as.integer(0) ~ NA_integer_, T~seats)) %>% 
+  dplyr::select(partyname, votesh, seats)
+
+#EES2019_ee_enhcdbk is from 
+#EESstacked\Scripts\aux_data_scripts\country_spec_aux_scripts\EES2019_enhcdbk_ee.R
 
 # Select the relevant parties # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 

--- a/Scripts/country_spec_scripts/EES2019_ee_stack.R
+++ b/Scripts/country_spec_scripts/EES2019_ee_stack.R
@@ -21,8 +21,6 @@ EES2019_cdbk_ee <-
   EES2019_cdbk %>% 
   filter(countryshort=='EE')
 
-#EES2019_cdbk is from EESstacked\Scripts\aux_data_scripts\EES2019_cdbk.R
-
 # Get the respondent ID codes # ========================================================================
 
 respid <- 
@@ -41,12 +39,9 @@ ptv_crit <-
 # Check the vote shares of parties that obtained at least one seat in the EP # - - - - - - - - - - - - -
 
 votes_crit <- 
-  EES2019_ee_enhcdbk %>% 
+  EES2019_cdbk_ee %>% 
   mutate(seats = case_when(seats==as.integer(0) ~ NA_integer_, T~seats)) %>% 
   dplyr::select(partyname, votesh, seats)
-
-#EES2019_ee_enhcdbk is from 
-#EESstacked\Scripts\aux_data_scripts\country_spec_aux_scripts\EES2019_enhcdbk_ee.R
 
 # Select the relevant parties # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 

--- a/Scripts/country_spec_scripts/EES2019_lu_stack.R
+++ b/Scripts/country_spec_scripts/EES2019_lu_stack.R
@@ -62,6 +62,10 @@ EES2019_lu_stack <-
          stack = paste0(respid, '-', party)) %>%
   dplyr::select(countrycode, respid, party, stack)
 
+#The parties Dei Lenk (DL ) (1805), Alternativ Demokratesch Reformpartei 
+#(ADR) (1806) and Piratepartei (PPL) (1807) don't have seats but are included 
+#in the dataframe.
+
 # Clean the environment # ==============================================================================
 
 rm(list=ls(pattern='_lu$|_crit$'))  

--- a/Scripts/country_spec_scripts/EES2019_lu_stack.R
+++ b/Scripts/country_spec_scripts/EES2019_lu_stack.R
@@ -1,7 +1,7 @@
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Title: Script for Stacking Observations (EES 2019 Voter Study, Luxembourg Sample) 
 # Author: W.Haeussling
-# last update: 2021-08-08
+# last update: 2021-08-27
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 # Keep the EES 2019 Luxembourg sample # ===================================================================
@@ -11,11 +11,11 @@ EES2019_lu <-
   filter(countrycode==1442)
 
 
-# Filter the codebook and EP elections data # ==========================================================
+# Filter the codebook data # ==========================================================
 
-EP2019_lu <- 
-  EP2019 %>% 
-  filter(countryshort=='LU')
+#EP2019_lu <- 
+#  EP2019 %>% 
+#  filter(countryshort=='LU')
 
 
 EES2019_cdbk_lu <- 
@@ -41,8 +41,9 @@ ptv_crit <-
 # Check the vote shares of parties that obtained at least one seat in the EP # - - - - - - - - - - - - -
 
 votes_crit <- 
-  EP2019_lu %>% 
-  filter(partyname!='Other parties') 
+  EES2019_cdbk_lu %>%
+  mutate(seats = case_when(seats==as.integer(0) ~ NA_integer_, T~seats)) %>% 
+  dplyr::select(partyname, votesh, seats) 
 
 # Select the relevant parties # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 

--- a/Scripts/country_spec_scripts/EES2019_mt_stack.R
+++ b/Scripts/country_spec_scripts/EES2019_mt_stack.R
@@ -11,11 +11,11 @@ EES2019_mt <-
   filter(countrycode==1470)
 
 
-# Filter the codebook and EP elections data # ==========================================================
+# Filter the codebook data # ===========================================================================
 
-EP2019_mt <- 
-  EP2019 %>% 
-  filter(countryshort=='MT')
+#EP2019_mt <- 
+#  EP2019 %>% 
+#  filter(countryshort=='MT')
 
 
 EES2019_cdbk_mt <- 
@@ -41,8 +41,9 @@ ptv_crit <-
 # Check the vote shares of parties that obtained at least one seat in the EP # - - - - - - - - - - - - -
 
 votes_crit <- 
-  EP2019_mt %>% 
-  filter(partyname!='Other parties') 
+  EES2019_cdbk_mt %>%
+  mutate(seats = case_when(seats==as.integer(0) ~ NA_integer_, T~seats)) %>% 
+  dplyr::select(partyname, votesh, seats)
 
 # Select the relevant parties # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 
@@ -60,6 +61,9 @@ EES2019_mt_stack <-
   mutate(countrycode=EES2019_mt$countrycode %>% unique,
          stack = paste0(respid, '-', party)) %>%
   dplyr::select(countrycode, respid, party, stack)
+
+#The parties Alternattiva Demokratika (1903), Partit Demokratiku (1904) and 
+#Imperu Ewropew (1905) don't have a seat but are included.
 
 # Clean the environment # ==============================================================================
 

--- a/Scripts/country_spec_scripts/EES2019_uk_stack.R
+++ b/Scripts/country_spec_scripts/EES2019_uk_stack.R
@@ -11,11 +11,11 @@ EES2019_uk <-
   filter(countrycode==1826)
 
 
-# Filter the codebook and EP elections data # ==========================================================
+# Filter the codebook data # ==========================================================
 
-EP2019_uk <- 
-  EP2019 %>% 
-  filter(countryshort=='UK')
+#EP2019_uk <- 
+#  EP2019 %>% 
+#  filter(countryshort=='UK')
 
 
 EES2019_cdbk_uk <- 
@@ -36,13 +36,14 @@ respid <-
 
 ptv_crit <-
   EES2019_cdbk_uk %>% 
-  dplyr::select(partyname, Q10_PTV) 
+  dplyr::select(partyname, Q10_PTV)
 
 # Check the vote shares of parties that obtained at least one seat in the EP # - - - - - - - - - - - - -
 
 votes_crit <- 
-  EP2019_uk %>% 
-  filter(partyname!='Other parties') 
+  EES2019_cdbk_uk %>%
+  mutate(seats = case_when(seats==as.integer(0) ~ NA_integer_, T~seats)) %>% 
+  dplyr::select(partyname, votesh, seats) 
 
 # Select the relevant parties # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 
@@ -60,6 +61,9 @@ EES2019_uk_stack <-
   mutate(countrycode=EES2019_uk$countrycode %>% unique,
          stack = paste0(respid, '-', party)) %>%
   dplyr::select(countrycode, respid, party, stack)
+
+#The party UKIP (2806) does not have a seat, but is included. The parties 
+#Plaid (2809), SF (2810) and DUP (2811) all have 1 seat, but are not included.
 
 # Clean the environment # ==============================================================================
 


### PR DESCRIPTION
Auxiliar data scripts and resulting changes to the country specific SDM scripts for Denmark, Estonia, Germany, Luxembourg, Malta and UK. (adding seats to the data frames (not all) as an additional column)