### PR TITLE
Synteval Scripts and R Markdown Codebook

### DIFF
--- a/Docs/Synteval/scripts/EES2019_synteval_mk.Rmd
+++ b/Docs/Synteval/scripts/EES2019_synteval_mk.Rmd
@@ -1,0 +1,1365 @@
+---
+title: Summary of Synthetic Variables Estimation 
+subtitle: EES 2019 Voter Study (Austrian, Croatian, French, Irish, Latvian, Portugues, Romanian and Slovenian samples)
+author: Matthias Körnig
+date: 10.11.2021 
+toc: false
+output: 
+  bookdown::pdf_document2:
+    includes:
+      in_header: eval_header.tex
+urlcolor: RedOrange
+---
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+
+# Load 'here' for sourcing # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - #
+library('here')
+
+# Source the general workflow # - - - - - - - - - - - - - - - - - - - - - - - - - - - - -#
+source(here('Scripts', 'synteval_scripts', 'Synteval_gen.R'))
+
+```
+
+\newpage
+# Austria
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+# Source the Austrain synteval script # - - - - - - - - - - - - - - - - - - - - - - - - - #
+
+source(here('Scripts', 'synteval_scripts', 'country_spec_scripts', 'EES2019_at_synteval.R'))
+
+```
+
+Synthetic variables have been estimated for the full set of Austrain parties available in the original 
+2019 EES Austrian voter study selected according to the criteria stated in the EES 2019 SDM codebook (
+for the criteria see Sect. XXX; for the relevant parties see Table \ref{table:relprty_tab_at}). 
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+options(knitr.kable.NA = 'NA')
+options(knitr.table.format = "latex")
+
+names(relprty_df) <- c('Dep. Var.', 'Party', 'Party name (eng)')
+
+relprty_df %>% 
+  kable(caption = "Austrian relevant parties \\label{table:relprty_tab_at}", booktabs = T, 
+        align = c('l', 'c', 'l')) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position'))
+
+```
+
+Full OLS models converge and coefficients do not show any particular issue (see Table 
+\ref{table:full_ols_at}). 
+In terms of model fit, the adjusted coefficient of determination ($R^2$) values vary between 
+a minimum value of `r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==min(Adj_Rsq)) %>% .[['Adj_Rsq']]` 
+for party `r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==min(Adj_Rsq)) %>% .[['partycode']]` 
+(`r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==min(Adj_Rsq)) %>% .[['partyname_eng']]`) 
+and a maximum of `r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==max(Adj_Rsq)) %>% .[['Adj_Rsq']]`
+for party `r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==max(Adj_Rsq)) %>% .[['partycode']]`
+(`r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==max(Adj_Rsq)) %>% .[['partyname_eng']]`). 
+Moreover, the difference between Akaike Information Criterion (AIC) values for full OLS models and null 
+models shows that in all 6 cases out of 6 null models perform better than full ones (see Table 
+\ref{table:ols_aic_at}).
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+
+
+names(ols_aic) <- c('Dep. Var.', 'Party', 'Full Mod.', 'Null Mod.', 'Diff. (Full-Null)')
+
+ols_aic %>% 
+  kable(caption = "Akaike Information Criterion values for OLS full and null models 
+        \\label{table:ols_aic_at}", booktabs = T, 
+        align = c('l', 'c', rep('r',3))) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position'))
+
+
+```
+
+On the contrary, one out of six logistic regression models (see Table \ref{table:full_logit_at}) show 
+inflated standard errors for some of the coefficients of interest: 
+
+* Model 12: D8_rec, D1_rec;
+
+Model 12 presents more problematic profile, since it affects the models constant terms with its inflated standard errors
+
+Model 12 inflated standard errors are due to separation issues. In short, no respondents from rural areas
+or small cities and members of trade unions did vote for party 505 (see Tables \ref{table:crosstab_1_at}, 
+\ref{table:crosstab_2_at}). 
+
+As a consequence, a constrained version of model 6 without said variables was 
+estimated and contrasted with the original, full model. Likelihood-ratio test results show 
+that $H_0$ (namely, that the constrained model does not fit better than the full model) can be rejected at p<0.001
+(see Table \ref{table:lrtest_1_at}). Consequently, synthetic variables for respondents' vote choice for 
+party 105 have been predicted relying on the unconstrained model. 
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+
+options(knitr.kable.NA = '')
+
+anova_lst[[1]] %>%
+  kable(caption = "Likelihood-ratio Test between Model 6a (Unconstrained) and Model 6b (Constrained)
+                  \\label{table:lrtest_1_at}", booktabs = F, ) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position'))
+
+```
+
+In terms of model fit, adjusted McFadden's pseudo $R^2$ values for the logistic full models vary between 
+a minimum value of 
+`r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==min(Adj_Ps_Rsq)) %>% .[['Adj_Ps_Rsq']] %>% round(.,3)` 
+for party `r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==min(Adj_Ps_Rsq)) %>% .[['partycode']]` 
+(`r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==min(Adj_Ps_Rsq)) %>% .[['partyname_eng']]`) 
+and a maximum of 
+`r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==max(Adj_Ps_Rsq)) %>% .[['Adj_Ps_Rsq']] %>% round(.,3)`
+for party `r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==max(Adj_Ps_Rsq)) %>% .[['partycode']]`
+(`r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==max(Adj_Ps_Rsq)) %>% .[['partyname_eng']]`). 
+Moreover, the difference between Akaike Information Criterion (AIC) values for logistic full models and 
+null models shows that in 5 cases out of 6 null models perform better than full ones.
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+
+logit_aic[6,1] <- 'stack_105*'
+
+names(logit_aic) <- c('Dep. Var.', 'Party', 'Full Mod.', 'Null Mod.', 'Diff. (Full-Null)')
+
+logit_aic %>% 
+  kable(caption = "Akaike Information Criterion values for logistic full and null models 
+        \\label{table:logit_aic_cy}", booktabs = T, 
+        align = c('l', 'c', rep('r',3))) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position')) %>% 
+  footnote(symbol = 'AIC value refers to Model 6b (constrained).',
+           threeparttable = T,
+           footnote_as_chunk = T)
+```
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+
+options(knitr.kable.NA = 'NA')
+
+tabs[[1]] %>% 
+  kable(caption = "Cross tabulation between vote choice for party 105 and respondents' area of residency 
+                   \\label{table:crosstab_1_at}", booktabs = F) %>%  #  align = c('l', 'c', rep('r',3))
+  kable_styling(latex_options = c('striped'))
+
+tabs[[2]] %>% 
+  kable(caption = "Cross tabulation between vote choice for party 105 and respondents' marital status
+                   \\label{table:crosstab_2_at}", booktabs = F) %>% 
+  kable_styling(latex_options = c('striped'))
+
+
+```
+
+
+```{r, results='asis', echo=F}
+
+stargazer::stargazer(finalmod_lst$OLS, 
+                     title = "Propensity to vote for a relevant party according to respondents' 
+                     socio-demographic characteristics (OLS regression models)",
+                     label = 'table:full_ols_at',
+                     type = 'latex',
+                     column.labels = c('101', '102', '104', '106','103', '105'),
+                     dep.var.labels.include = F,
+                     star.cutoffs = c(0.05, 0.01, 0.001),
+                     omit.stat=c("f", "ser"),
+                     header = F,
+                     style = 'ajps')
+
+logit_regtab <- 
+  stargazer::stargazer(finalmod_lst$logit, 
+                       title = "Vote choice for a relevant party according to respondents' 
+                       socio-demographic characteristics (Logistic regression models)",
+                       label = 'table:full_logit_at',
+                       type = 'latex',
+                       column.labels = c('101', '102', '104', '106','103', '105'),
+                       dep.var.labels.include = F,
+                       star.cutoffs = c(0.05, 0.01, 0.001),
+                       omit.stat=c("f", "ser"),
+                       header = F,
+                       style = 'ajps') %>% 
+  capture.output() 
+
+logit_regtab[9] %<>%
+  gsub('Model 1', 'Model 7',.) %>%
+  gsub('Model 6', 'Model 12',.) %>% 
+  gsub('Model 5', 'Model 11',.) %>% 
+  gsub('Model 4', 'Model 10',.) %>% 
+  gsub('Model 3', 'Model 9',.) %>% 
+  gsub('Model 2', 'Model 8',.) 
+
+cat(logit_regtab, sep = "\n")
+  
+
+```
+
+
+
+\newpage
+# Croatia
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+# Source the Croatian synteval script # - - - - - - - - - - - - - - - - - - - - - - - - - #
+
+source(here('Scripts', 'synteval_scripts', 'country_spec_scripts', 'EES2019_hr_synteval.R'))
+
+```
+
+Synthetic variables have been estimated for the full set of Croatian parties available in the original 
+2019 EES Croatian voter study selected according to the criteria stated in the EES 2019 SDM codebook (
+for the criteria see Sect. XXX; for the relevant parties see Table \ref{table:relprty_tab_hr}). 
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+options(knitr.kable.NA = 'NA')
+options(knitr.table.format = "latex")
+
+names(relprty_df) <- c('Dep. Var.', 'Party', 'Party name (eng)')
+
+relprty_df %>% 
+  kable(caption = "Croatian relevant parties \\label{table:relprty_tab_hr}", booktabs = T, 
+        align = c('l', 'c', 'l')) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position'))
+
+```
+
+Full OLS models converge and coefficients do not show any particular issue (see Table 
+\ref{table:full_ols_hr}). 
+In terms of model fit, the adjusted coefficient of determination ($R^2$) values vary between 
+a minimum value of `r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==min(Adj_Rsq)) %>% .[['Adj_Rsq']]` 
+for party `r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==min(Adj_Rsq)) %>% .[['partycode']]` 
+(`r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==min(Adj_Rsq)) %>% .[['partyname_eng']]`) 
+and a maximum of `r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==max(Adj_Rsq)) %>% .[['Adj_Rsq']]`
+for party `r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==max(Adj_Rsq)) %>% .[['partycode']]`
+(`r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==max(Adj_Rsq)) %>% .[['partyname_eng']]`). 
+Moreover, the difference between Akaike Information Criterion (AIC) values for full OLS models and null 
+models shows that in all 7 cases out of 7 null models perform better than full ones (see Table 
+\ref{table:ols_aic_hr}).
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+
+
+names(ols_aic) <- c('Dep. Var.', 'Party', 'Full Mod.', 'Null Mod.', 'Diff. (Full-Null)')
+
+ols_aic %>% 
+  kable(caption = "Akaike Information Criterion values for OLS full and null models 
+        \\label{table:ols_aic_hr}", booktabs = T, 
+        align = c('l', 'c', rep('r',3))) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position'))
+
+
+```
+
+On the contrary, two out of seven logistic regression models (see Table \ref{table:full_logit_hr}) show 
+inflated standard errors for some of the coefficients of interest, in particular: 
+
+* Model 8a: D8_rec, D5_rec, EDU_rec, D7_rec (only for category 2), D6_une;
+* Model 13a: EDU_rec, D6_une;
+
+Those models 14a and 13a present more problematic profiles, since they affect its models constant terms through their inflated standard errors.
+
+Model 8a and 13a inflated standard errors are due to separation issues. In short, no respondents with low education and in unemployment 
+did vote for party 413 (see Tables \ref{table:crosstab_1_hr}, \ref{table:crosstab_2_hr}). As well as no respondents from rural areas
+or small cities, single, low educated, with high subjective socioeconomic status (SES) and unemployed did vote for party 401 (see Tables \ref{table:crosstab_3_hr}, \ref{table:crosstab_4_hr}, \ref{table:crosstab_5_hr}, \ref{table:crosstab_6_hr}, \ref{table:crosstab_7_hr}). 
+
+As a consequence, a constrained version of model 8 and 13 (namely, Model 14b, 13b) without said variables was 
+estimated and contrasted with the original (Model 14a, 13a), full model. Likelihood-ratio test results show 
+that $H_0$ (namely, that the constrained model fits better than the full model)  can be rejected at p<0.1 for 
+party 401 (see Table \ref{table:lrtest_1_hr}). For party 413 $H_0$ cannot be rejected (see Table \ref{table:lrtest_2_hr}) Consequently, synthetic variables 
+for respondents' vote choice for party 401 and 413 have been predicted relying on the constrained model (Model 14b, 13b). 
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+
+options(knitr.kable.NA = '')
+
+anova_lst[[2]] %>%
+  kable(caption = "Likelihood-ratio Test between Model 14a (Unconstrained) and Model 8b (Constrained)
+                  \\label{table:lrtest_1_hr}", booktabs = F, ) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position'))
+
+anova_lst[[1]] %>%
+  kable(caption = "Likelihood-ratio Test between Model 13a (Unconstrained) and Model 13b (Constrained)
+                  \\label{table:lrtest_2_hr}", booktabs = F, ) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position'))
+
+```
+
+In terms of model fit, adjusted McFadden's pseudo $R^2$ values for the logistic full models vary between 
+a minimum value of 
+`r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==min(Adj_Ps_Rsq)) %>% .[['Adj_Ps_Rsq']] %>% round(.,3)` 
+for party `r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==min(Adj_Ps_Rsq)) %>% .[['partycode']]` 
+(`r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==min(Adj_Ps_Rsq)) %>% .[['partyname_eng']]`) 
+and a maximum of 
+`r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==max(Adj_Ps_Rsq)) %>% .[['Adj_Ps_Rsq']] %>% round(.,3)`
+for party `r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==max(Adj_Ps_Rsq)) %>% .[['partycode']]`
+(`r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==max(Adj_Ps_Rsq)) %>% .[['partyname_eng']]`). 
+Moreover, the difference between Akaike Information Criterion (AIC) values for logistic full models and 
+null models shows that in 3 cases out of 7 null models perform better than full ones. According to AIC 
+values the related null models appear to have a better fit than Model 13b and 14b (see Table
+\ref{table:logit_aic_hr}). 
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+
+logit_aic[2,1] <- 'stack_401*'
+logit_aic[8,1] <- 'stack_413*'
+
+names(logit_aic) <- c('Dep. Var.', 'Party', 'Full Mod.', 'Null Mod.', 'Diff. (Full-Null)')
+
+logit_aic %>% 
+  kable(caption = "Akaike Information Criterion values for logistic full and null models 
+        \\label{table:logit_aic_hr}", booktabs = T, 
+        align = c('l', 'c', rep('r',3))) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position')) %>% 
+  footnote(symbol = 'AIC value refers to Model 13b and 14b (constrained).',
+           threeparttable = T,
+           footnote_as_chunk = T)
+```
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+
+options(knitr.kable.NA = 'NA')
+
+tabs[[1]] %>% 
+  kable(caption = "Cross tabulation between vote choice for party 413 and respondents' education 
+                   \\label{table:crosstab_1_hr}", booktabs = F) %>%  #  align = c('l', 'c', rep('r',3))
+  kable_styling(latex_options = c('striped'))
+
+tabs[[2]] %>% 
+  kable(caption = "Cross tabulation between vote choice for party 413 and respondents' employment status
+                   \\label{table:crosstab_2_hr}", booktabs = F) %>% 
+  kable_styling(latex_options = c('striped'))
+
+tabs2[[1]] %>% 
+  kable(caption = "Cross tabulation between vote choice for party 401 and respondents' education
+                   \\label{table:crosstab_3_hr}", booktabs = F) %>% 
+  kable_styling(latex_options = c('striped'))
+
+tabs2[[2]] %>% 
+  kable(caption = "Cross tabulation between vote choice for party 401 and respondents' employment status 
+                   \\label{table:crosstab_4_hr}", booktabs = F) %>% 
+  kable_styling(latex_options = c('striped'))
+
+tabs2[[3]] %>% 
+  kable(caption = "Cross tabulation between vote choice for party 401 and respondents' subjective SES
+                   membership \\label{table:crosstab_5_hr}", booktabs = F) %>% 
+  kable_styling(latex_options = c('striped'))
+
+tabs2[[4]] %>% 
+  kable(caption = "Cross tabulation between vote choice for party 401 and respondents' marital status
+                  \\label{table:crosstab_6_hr}", booktabs = F) %>% 
+  kable_styling(latex_options = c('striped'))
+
+tabs2[[5]] %>% 
+  kable(caption = "Cross tabulation between vote choice for party 401 and respondents' area of residency 
+                  \\label{table:crosstab_7_hr}", booktabs = F) %>% 
+  kable_styling(latex_options = c('striped'))
+
+```
+
+
+```{r, results='asis', echo=F}
+
+stargazer::stargazer(finalmod_lst$OLS, 
+                     title = "Propensity to vote for a relevant party according to respondents' 
+                     socio-demographic characteristics (OLS regression models)",
+                     label = 'table:full_ols_hr',
+                     type = 'latex',
+                     column.labels = c('412', '404', '414', '405','406', '413', '401'),
+                     dep.var.labels.include = F,
+                     star.cutoffs = c(0.05, 0.01, 0.001),
+                     omit.stat=c("f", "ser"),
+                     header = F,
+                     style = 'ajps')
+
+logit_regtab <- 
+  stargazer::stargazer(finalmod_lst$logit, 
+                       title = "Vote choice for a relevant party according to respondents' 
+                       socio-demographic characteristics (Logistic regression models)",
+                       label = 'table:full_logit_hr',
+                       type = 'latex',
+                       no.space = T, # to remove the spaces after each line of coefficients
+                       column.sep.width = '0.5pt', # to reduce column width
+                       font.size = 'footnotesize', # to make font size smaller
+                       column.labels = c('412', '404', '414', '405','406', '413',  '413', '401', '401'),
+                       dep.var.labels.include = F,
+                       star.cutoffs = c(0.05, 0.01, 0.001),
+                       omit.stat=c("f", "ser"),
+                       header = F,
+                       style = 'ajps') %>% 
+  capture.output() 
+
+logit_regtab[9] %<>%
+  gsub('Model 9', 'Model 14b',.) %>%
+  gsub('Model 8', 'Model 14a',.) %>%
+  gsub('Model 7', 'Model 13b',.) %>% 
+  gsub('Model 1$', 'Model 8',.) %>% 
+  gsub('Model 6', 'Model 13a',.) %>% 
+  gsub('Model 5', 'Model 12',.) %>% 
+  gsub('Model 4', 'Model 11',.) %>% 
+  gsub('Model 3', 'Model 10',.) %>% 
+  gsub('Model 2', 'Model 9',.) 
+  
+
+cat(logit_regtab, sep = "\n")
+  
+
+```
+
+
+
+\newpage
+# France
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+# Source the French synteval script # - - - - - - - - - - - - - - - - - - - - - - - - - #
+
+source(here('Scripts', 'synteval_scripts', 'country_spec_scripts', 'EES2019_fr_synteval.R'))
+
+```
+
+Synthetic variables have been estimated for the full set of French parties available in the original 
+2019 EES French voter study selected according to the criteria stated in the EES 2019 SDM codebook (
+for the criteria see Sect. XXX; for the relevant parties see Table \ref{table:relprty_tab_fr}). 
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+options(knitr.kable.NA = 'NA')
+options(knitr.table.format = "latex")
+
+names(relprty_df) <- c('Dep. Var.', 'Party', 'Party name (eng)')
+
+relprty_df %>% 
+  kable(caption = "French relevant parties \\label{table:relprty_tab_fr}", booktabs = T, 
+        align = c('l', 'c', 'l')) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position'))
+
+```
+
+Full OLS models converge and coefficients do not show any particular issue (see Table 
+\ref{table:full_ols_fr}). 
+In terms of model fit, the adjusted coefficient of determination ($R^2$) values vary between 
+a minimum value of `r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==min(Adj_Rsq)) %>% .[['Adj_Rsq']]` 
+for party `r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==min(Adj_Rsq)) %>% .[['partycode']]` 
+(`r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==min(Adj_Rsq)) %>% .[['partyname_eng']]`) 
+and a maximum of `r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==max(Adj_Rsq)) %>% .[['Adj_Rsq']]`
+for party `r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==max(Adj_Rsq)) %>% .[['partycode']]`
+(`r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==max(Adj_Rsq)) %>% .[['partyname_eng']]`). 
+Moreover, the difference between Akaike Information Criterion (AIC) values for full OLS models and null 
+models shows that in 7 cases out of 7 null models perform better than full ones (see Table 
+\ref{table:ols_aic_fr}).
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+
+
+names(ols_aic) <- c('Dep. Var.', 'Party', 'Full Mod.', 'Null Mod.', 'Diff. (Full-Null)')
+
+ols_aic %>% 
+  kable(caption = "Akaike Information Criterion values for OLS full and null models 
+        \\label{table:ols_aic_fr}", booktabs = T, 
+        align = c('l', 'c', rep('r',3))) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position'))
+
+
+```
+
+Also the full Logit models converge and coefficients do not show any particular issue (see Table \ref{table:full_logit_fr}) 
+In terms of model fit, adjusted McFadden's pseudo $R^2$ values for the logistic full models vary between 
+a minimum value of 
+`r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==min(Adj_Ps_Rsq)) %>% .[['Adj_Ps_Rsq']] %>% round(.,3)` 
+for party `r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==min(Adj_Ps_Rsq)) %>% .[['partycode']]` 
+(`r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==min(Adj_Ps_Rsq)) %>% .[['partyname_eng']]`) 
+and a maximum of 
+`r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==max(Adj_Ps_Rsq)) %>% .[['Adj_Ps_Rsq']] %>% round(.,3)`
+for party `r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==max(Adj_Ps_Rsq)) %>% .[['partycode']]`
+(`r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==max(Adj_Ps_Rsq)) %>% .[['partyname_eng']]`). 
+Moreover, the difference between Akaike Information Criterion (AIC) values for logistic full models and 
+null models shows that in 2 cases out of 6 null models perform better than full ones.
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+
+names(logit_aic) <- c('Dep. Var.', 'Party', 'Full Mod.', 'Null Mod.', 'Diff. (Full-Null)')
+
+logit_aic %>% 
+  kable(caption = "Akaike Information Criterion values for logistic full and null models 
+        \\label{table:logit_aic_fr}", booktabs = T, 
+        align = c('l', 'c', rep('r',3))) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position')) 
+  
+```
+
+
+
+```{r, results='asis', echo=F}
+
+stargazer::stargazer(finalmod_lst$OLS, 
+                     title = "Propensity to vote for a relevant party according to respondents' 
+                     socio-demographic characteristics (OLS regression models)",
+                     label = 'table:full_ols_fr',
+                     type = 'latex',
+                     column.labels = c('1113', '1105', '1111', '1114','1101', '1110', '1102'),
+                     dep.var.labels.include = F,
+                     star.cutoffs = c(0.05, 0.01, 0.001),
+                     omit.stat=c("f", "ser"),
+                     header = F,
+                     style = 'ajps')
+
+logit_regtab <- 
+  stargazer::stargazer(finalmod_lst$logit, 
+                       title = "Vote choice for a relevant party according to respondents' 
+                       socio-demographic characteristics (Logistic regression models)",
+                       label = 'table:full_logit_fr',
+                       type = 'latex',
+                       column.labels = c('1113', '1105', '1111', '1114','1101', '1110', '1102'),
+                       dep.var.labels.include = F,
+                       star.cutoffs = c(0.05, 0.01, 0.001),
+                       omit.stat=c("f", "ser"),
+                       header = F,
+                       style = 'ajps') %>% 
+  capture.output() 
+
+logit_regtab[9] %<>%
+  gsub('Model 1', 'Model 8',.) %>%
+  gsub('Model 7', 'Model 14',.) %>% 
+  gsub('Model 6', 'Model 13',.) %>% 
+  gsub('Model 5', 'Model 12',.) %>% 
+  gsub('Model 4', 'Model 11',.) %>% 
+  gsub('Model 3', 'Model 10',.) %>% 
+  gsub('Model 2', 'Model 9',.) 
+
+cat(logit_regtab, sep = "\n")
+  
+
+```
+
+\newpage
+\newpage
+# Ireland
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+# Source the Irish synteval script # - - - - - - - - - - - - - - - - - - - - - - - - - #
+
+source(here('Scripts', 'synteval_scripts', 'country_spec_scripts', 'EES2019_ie_synteval.R'))
+
+```
+
+Synthetic variables have been estimated for the full set of Irish parties available in the original 
+2019 EES Irish voter study selected according to the criteria stated in the EES 2019 SDM codebook (
+for the criteria see Sect. XXX; for the relevant parties see Table \ref{table:relprty_tab_ie}). 
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+options(knitr.kable.NA = 'NA')
+options(knitr.table.format = "latex")
+
+names(relprty_df) <- c('Dep. Var.', 'Party', 'Party name (eng)')
+
+relprty_df %>% 
+  kable(caption = "Irish relevant parties \\label{table:relprty_tab_ie}", booktabs = T, 
+        align = c('l', 'c', 'l')) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position'))
+
+```
+
+Full OLS models converge and coefficients do not show any particular issue (see Table 
+\ref{table:full_ols_ie}). 
+In terms of model fit, the adjusted coefficient of determination ($R^2$) values vary between 
+a minimum value of `r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==min(Adj_Rsq)) %>% .[['Adj_Rsq']]` 
+for party `r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==min(Adj_Rsq)) %>% .[['partycode']]` 
+(`r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==min(Adj_Rsq)) %>% .[['partyname_eng']]`) 
+and a maximum of `r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==max(Adj_Rsq)) %>% .[['Adj_Rsq']]`
+for party `r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==max(Adj_Rsq)) %>% .[['partycode']]`
+(`r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==max(Adj_Rsq)) %>% .[['partyname_eng']]`). 
+Moreover, the difference between Akaike Information Criterion (AIC) values for full OLS models and null 
+models shows that in 6 cases out of 6 null models perform better than full ones (see Table 
+\ref{table:ols_aic_ie}).
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+
+
+names(ols_aic) <- c('Dep. Var.', 'Party', 'Full Mod.', 'Null Mod.', 'Diff. (Full-Null)')
+
+ols_aic %>% 
+  kable(caption = "Akaike Information Criterion values for OLS full and null models 
+        \\label{table:ols_aic_ie}", booktabs = T, 
+        align = c('l', 'c', rep('r',3))) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position'))
+
+
+```
+
+On the contrary, one out of six logistic regression models (see Table \ref{table:full_logit_ie}) shows 
+inflated standard errors for one of the coefficients of interest: 
+
+* Model 8: EDU_rec;
+
+It presents a problematic profile since the inflated standard error is affecting the constant term.
+
+Model 8a inflated standard errors are due to separation issues. In short, only one low educated 
+respondent did vote for party 1403 (see Tables \ref{table:crosstab_1_ie})
+
+As a consequence, a constrained version of model 8 (namely, Model 8b) without said variables was 
+estimated and contrasted with the original (Model 8a), full model. Likelihood-ratio test results show 
+that $H_0$ (namely, that the constrained model fits better than the full model) cannot be rejected 
+(see Table \ref{table:lrtest_1_ie}). Consequently, synthetic variables for respondents' vote choice for 
+party 1403 have been predicted relying on the constrained model (Model 8b). 
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+
+options(knitr.kable.NA = '')
+
+anova_lst[[1]] %>%
+  kable(caption = "Likelihood-ratio Test between Model 8a (Unconstrained) and Model 8b (Constrained)
+                  \\label{table:lrtest_1_ie}", booktabs = F, ) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position'))
+
+```
+
+In terms of model fit, adjusted McFadden's pseudo $R^2$ values for the logistic full models vary between 
+a minimum value of 
+`r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==min(Adj_Ps_Rsq)) %>% .[['Adj_Ps_Rsq']] %>% round(.,3)` 
+for party `r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==min(Adj_Ps_Rsq)) %>% .[['partycode']]` 
+(`r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==min(Adj_Ps_Rsq)) %>% .[['partyname_eng']]`) 
+and a maximum of 
+`r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==max(Adj_Ps_Rsq)) %>% .[['Adj_Ps_Rsq']] %>% round(.,3)`
+for party `r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==max(Adj_Ps_Rsq)) %>% .[['partycode']]`
+(`r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==max(Adj_Ps_Rsq)) %>% .[['partyname_eng']]`). 
+Moreover, the difference between Akaike Information Criterion (AIC) values for logistic full models and 
+null models shows that in 4 cases out of 6 null models perform better than full ones. According to AIC 
+values the related null model appears to have a better fit than Model 8b (see Table
+\ref{table:logit_aic_ie}). 
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+
+logit_aic[4,1] <- 'stack_1403*'
+
+names(logit_aic) <- c('Dep. Var.', 'Party', 'Full Mod.', 'Null Mod.', 'Diff. (Full-Null)')
+
+logit_aic %>% 
+  kable(caption = "Akaike Information Criterion values for logistic full and null models 
+        \\label{table:logit_aic_ie}", booktabs = T, 
+        align = c('l', 'c', rep('r',3))) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position')) %>% 
+  footnote(symbol = 'AIC value refers to Model 8b (constrained).',
+           threeparttable = T,
+           footnote_as_chunk = T)
+```
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+
+options(knitr.kable.NA = 'NA')
+
+tabs[[1]] %>% 
+  kable(caption = "Cross tabulation between vote choice for party 505 and respondents' education 
+                   \\label{table:crosstab_1_ie}", booktabs = F) %>%  #  align = c('l', 'c', rep('r',3))
+  kable_styling(latex_options = c('striped'))
+
+```
+
+
+```{r, results='asis', echo=F}
+
+stargazer::stargazer(finalmod_lst$OLS, 
+                     title = "Propensity to vote for a relevant party according to respondents' 
+                     socio-demographic characteristics (OLS regression models)",
+                     label = 'table:full_ols_ie',
+                     type = 'latex',
+                     column.labels = c('1402', '1403', '1401', '1404','1405', '1406'),
+                     dep.var.labels.include = F,
+                     star.cutoffs = c(0.05, 0.01, 0.001),
+                     omit.stat=c("f", "ser"),
+                     header = F,
+                     style = 'ajps')
+
+logit_regtab <- 
+  stargazer::stargazer(finalmod_lst$logit, 
+                       title = "Vote choice for a relevant party according to respondents' 
+                       socio-demographic characteristics (Logistic regression models)",
+                       label = 'table:full_logit_ie',
+                       type = 'latex',
+                       column.labels = c('1402', '1403', '1403', '1401', '1404','1405', '1406'),
+                       dep.var.labels.include = F,
+                       star.cutoffs = c(0.05, 0.01, 0.001),
+                       omit.stat=c("f", "ser"),
+                       header = F,
+                       style = 'ajps') %>% 
+  capture.output() 
+
+logit_regtab[9] %<>%
+  gsub('Model 7', 'Model 12',.) %>% 
+  gsub('Model 1$', 'Model 7',.) %>% 
+  gsub('Model 6', 'Model 11',.) %>% 
+  gsub('Model 5', 'Model 10',.) %>% 
+  gsub('Model 4', 'Model 9',.) %>% 
+  gsub('Model 3', 'Model 8b',.) %>% 
+  gsub('Model 2', 'Model 8a',.) 
+
+cat(logit_regtab, sep = "\n")
+  
+
+```
+
+
+
+\newpage
+# Latvia
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+# Source the Latvian synteval script # - - - - - - - - - - - - - - - - - - - - - - - - - #
+
+source(here('Scripts', 'synteval_scripts', 'country_spec_scripts', 'EES2019_lv_synteval.R'))
+
+```
+
+Synthetic variables have been estimated for the full set of Latvian parties available in the original 
+2019 EES Latvian voter study selected according to the criteria stated in the EES 2019 SDM codebook (
+for the criteria see Sect. XXX; for the relevant parties see Table \ref{table:relprty_tab_lv}). 
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+options(knitr.kable.NA = 'NA')
+options(knitr.table.format = "latex")
+
+names(relprty_df) <- c('Dep. Var.', 'Party', 'Party name (eng)')
+
+relprty_df %>% 
+  kable(caption = "latvian relevant parties \\label{table:relprty_tab_lv}", booktabs = T, 
+        align = c('l', 'c', 'l')) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position'))
+
+```
+
+Full OLS models converge and coefficients do not show any particular issue (see Table 
+\ref{table:full_ols_lv}). 
+In terms of model fit, the adjusted coefficient of determination ($R^2$) values vary between 
+a minimum value of `r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==min(Adj_Rsq)) %>% .[['Adj_Rsq']]` 
+for party `r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==min(Adj_Rsq)) %>% .[['partycode']]` 
+(`r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==min(Adj_Rsq)) %>% .[['partyname_eng']]`) 
+and a maximum of `r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==max(Adj_Rsq)) %>% .[['Adj_Rsq']]`
+for party `r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==max(Adj_Rsq)) %>% .[['partycode']]`
+(`r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==max(Adj_Rsq)) %>% .[['partyname_eng']]`). 
+Moreover, the difference between Akaike Information Criterion (AIC) values for full OLS models and null 
+models shows that in 5 cases out of 7 null models perform better than full ones (see Table 
+\ref{table:ols_aic_lv}).
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+
+
+names(ols_aic) <- c('Dep. Var.', 'Party', 'Full Mod.', 'Null Mod.', 'Diff. (Full-Null)')
+
+ols_aic %>% 
+  kable(caption = "Akaike Information Criterion values for OLS full and null models 
+        \\label{table:ols_aic_lv}", booktabs = T, 
+        align = c('l', 'c', rep('r',3))) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position'))
+
+
+```
+
+On the contrary, six out of seven logistic regression models (see Tables \ref{table:full_logit_lv_p1},
+\ref{table:full_logit_lv_p2}) show inflated standard errors for some of the coefficients of interest, 
+in particular: 
+
+* Model 8,14: EDU_rec, D6_une;
+* Model 9: D6_une;
+* Model 11: D5_rec;
+* Model 12,13: EDU_rec.
+
+Nevertheless, models 9 and 11 constant terms and other regression coefficients are not affected by said 
+inflated standard errors, whereas model 8,12,13,14 presents a more problematic profile. 
+
+Models 8,12,13,14 inflated standard errors are due to separation issues. In short, no respondents with low 
+education and unemployement did vote for party 1611 and 1616 (see Tables \ref{table:crosstab_1_lv}, 
+\ref{table:crosstab_2_lv}, \ref{table:crosstab_3_lv}, \ref{table:crosstab_4_lv}). For party 1610 and 1604
+no respondents with low education voted for them (see Tables \ref{table:crosstab_5_lv}, \ref{table:crosstab_6_lv}). 
+
+As a consequence, a constrained version of model 8,12,13,14 (namely, Model 8b,12b,13b,14b) without said variables was 
+estimated and contrasted with the original (Model 8a,12a,13a,14a), full model. Likelihood-ratio test results show 
+
+* that for Model 8 $H_0$ (namely, that the constrained model fits better than the full model) can be rejected at p<0.05 (see Table \ref{table:lrtest_1_lv}). However, if just EDU_rec is dropped, $H_0$ can be rejected at p<0.1 and the constant term is also not affected (see Table \ref{table:lrtest_2_lv}). Thus, synthetic variables for respondents' vote choice for party 1611 have been predicted relying on the constrained model dropping only EDU_rec.
+* that for Model 12 $H_0$ can be rejected at p<0.1 (see Table \ref{table:lrtest_3_lv}). Consequently, synthetic variables for respondents' vote choice for 
+party 1610 have been predicted relying on the constrained model (Model 12b).
+* that for Model 13 $H_0$ can be rejected at p<0.05 (see Table \ref{table:lrtest_4_lv}). Consequently, synthetic variables for respondents' vote choice for 
+party 1604 have been predicted relying on the constrained model (Model 13b).
+* that for Model 14 $H_0$ can be rejected at p<0.001 (see Table \ref{table:lrtest_5_lv}). Consequently, synthetic variables for respondents' vote choice for 
+party 1616 have been predicted relying on the unconstrained model (Model 14).
+
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+
+options(knitr.kable.NA = '')
+
+anova_lst2[[1]] %>%
+  kable(caption = "Likelihood-ratio Test between Model 8a (Unconstrained) and (Fully Constrained)
+                  \\label{table:lrtest_1_lv}", booktabs = F, ) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position'))
+
+anova_lst[[1]] %>%
+  kable(caption = "Likelihood-ratio Test between Model 8a (Unconstrained) and Model 8b (Constrained)
+                  \\label{table:lrtest_2_lv}", booktabs = F, ) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position'))
+
+anova_lst[[4]] %>%
+  kable(caption = "Likelihood-ratio Test between Model 12a (Unconstrained) and Model 12b (Constrained)
+                  \\label{table:lrtest_3_lv}", booktabs = F, ) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position'))
+
+anova_lst[[5]] %>%
+  kable(caption = "Likelihood-ratio Test between Model 13a (Unconstrained) and Model 13b (Constrained)
+                  \\label{table:lrtest_4_lv}", booktabs = F, ) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position'))
+
+anova_lst[[6]] %>%
+  kable(caption = "Likelihood-ratio Test between Model 14 (Unconstrained and Constrained)
+                  \\label{table:lrtest_5_lv}", booktabs = F, ) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position'))
+
+```
+
+In terms of model fit, adjusted McFadden's pseudo $R^2$ values for the logistic full models vary between 
+a minimum value of 
+`r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==min(Adj_Ps_Rsq)) %>% .[['Adj_Ps_Rsq']] %>% round(.,3)` 
+for party `r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==min(Adj_Ps_Rsq)) %>% .[['partycode']]` 
+(`r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==min(Adj_Ps_Rsq)) %>% .[['partyname_eng']]`) 
+and a maximum of 
+`r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==max(Adj_Ps_Rsq)) %>% .[['Adj_Ps_Rsq']] %>% round(.,3)`
+for party `r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==max(Adj_Ps_Rsq)) %>% .[['partycode']]`
+(`r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==max(Adj_Ps_Rsq)) %>% .[['partyname_eng']]`). 
+Moreover, the difference between Akaike Information Criterion (AIC) values for logistic full models and 
+null models shows that in 3 cases out of 7 null models perform better than full ones. According to AIC 
+values the related null model appears to have a better fit than Model 11b (see Table
+\ref{table:logit_aic_lv}). 
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+
+logit_aic[2,1] <- 'stack_1611*'
+logit_aic[9,1] <- 'stack_1610*'
+logit_aic[11,1] <- 'stack_1604*'
+
+names(logit_aic) <- c('Dep. Var.', 'Party', 'Full Mod.', 'Null Mod.', 'Diff. (Full-Null)')
+
+logit_aic %>% 
+  kable(caption = "Akaike Information Criterion values for logistic full and null models 
+        \\label{table:logit_aic_lv}", booktabs = T, 
+        align = c('l', 'c', rep('r',3))) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position')) %>% 
+  footnote(symbol = 'AIC value refers to Model 11b (constrained).',
+           threeparttable = T,
+           footnote_as_chunk = T)
+```
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+
+options(knitr.kable.NA = 'NA')
+
+tabs[[1]] %>% 
+  kable(caption = "Cross tabulation between vote choice for party 1611 and respondents' education
+                   \\label{table:crosstab_1_lv}", booktabs = F) %>%  #  align = c('l', 'c', rep('r',3))
+  kable_styling(latex_options = c('striped'))
+
+tabs[[2]] %>% 
+  kable(caption = "Cross tabulation between vote choice for party 1611 and respondents' employment status
+                   \\label{table:crosstab_2_lv}", booktabs = F) %>% 
+  kable_styling(latex_options = c('striped'))
+
+tabs6[[1]] %>% 
+  kable(caption = "Cross tabulation between vote choice for party 1616 and respondents' education 
+                   \\label{table:crosstab_3_lv}", booktabs = F) %>% 
+  kable_styling(latex_options = c('striped'))
+
+tabs6[[2]] %>% 
+  kable(caption = "Cross tabulation between vote choice for party 1616 and respondents' employment status
+                   \\label{table:crosstab_4_lv}", booktabs = F) %>% 
+  kable_styling(latex_options = c('striped'))
+
+tabs4[[1]] %>% 
+  kable(caption = "Cross tabulation between vote choice for party 1610 and respondents' education
+                   membership \\label{table:crosstab_5_lv}", booktabs = F) %>% 
+  kable_styling(latex_options = c('striped'))
+
+tabs5[[1]] %>% 
+  kable(caption = "Cross tabulation between vote choice for party 1604 and respondents' education
+                  \\label{table:crosstab_6_lv}", booktabs = F) %>% 
+  kable_styling(latex_options = c('striped'))
+
+```
+
+
+```{r, results='asis', echo=F}
+
+stargazer::stargazer(finalmod_lst$OLS, 
+                     title = "Propensity to vote for a relevant party according to respondents' 
+                     socio-demographic characteristics (OLS regression models)",
+                     label = 'table:full_ols_lv',
+                     type = 'latex',
+                     column.labels = c('1611', '1608', '1609', '1605','1610', '1604', '1616'),
+                     dep.var.labels.include = F,
+                     star.cutoffs = c(0.05, 0.01, 0.001),
+                     omit.stat=c("f", "ser"),
+                     header = F,
+                     style = 'ajps')
+
+
+finalmod_lst2 <- finalmod_lst[["logit"]][-c(6,7,8,9,10)]
+finalmod_lst3 <- finalmod_lst[["logit"]][-c(1,2,3,4,5)]
+
+logit_regtab <- 
+  stargazer::stargazer(finalmod_lst2, 
+                       title = "Vote choice for a relevant party according to respondents' 
+                       socio-demographic characteristics (Logistic regression models)",
+                       label = 'table:full_logit_lv_p1',
+                       type = 'latex',
+                       column.labels = c('1611', '1611', '1608', '1609', '1605'),
+                       dep.var.labels.include = F,
+                       star.cutoffs = c(0.05, 0.01, 0.001),
+                       omit.stat=c("f", "ser"),
+                       header = F,
+                       style = 'ajps') %>% 
+  capture.output() 
+
+logit_regtab2 <- 
+  stargazer::stargazer(finalmod_lst3, 
+                       title = "Vote choice for a relevant party according to respondents' 
+                       socio-demographic characteristics (Logistic regression models)",
+                       label = 'table:full_logit_lv_p2',
+                       type = 'latex',
+                       column.labels = c('1610', '1610', '1604', '1604', '1616'),
+                       dep.var.labels.include = F,
+                       star.cutoffs = c(0.05, 0.01, 0.001),
+                       omit.stat=c("f", "ser"),
+                       header = F,
+                       style = 'ajps') %>% 
+  capture.output() 
+
+
+logit_regtab[9] %<>%
+  gsub('Model 1', 'Model 8',.) %>% 
+  gsub('Model 2', 'Model 8a',.) %>% 
+  gsub('Model 3', 'Model 9',.) %>% 
+  gsub('Model 4', 'Model 10',.) %>% 
+  gsub('Model 5', 'Model 11',.)
+
+cat(logit_regtab, sep = "\n")
+
+logit_regtab2[9] %<>%
+  gsub('Model 1', 'Model 12a',.) %>% 
+  gsub('Model 2', 'Model 12b',.) %>% 
+  gsub('Model 3', 'Model 13a',.) %>% 
+  gsub('Model 4', 'Model 13b',.) %>% 
+  gsub('Model 5', 'Model 14',.) 
+
+cat(logit_regtab2, sep = "\n")
+  
+  
+
+```
+
+
+\newpage
+# Romania
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+# Source the Romanian synteval script # - - - - - - - - - - - - - - - - - - - - - - - - - #
+
+source(here('Scripts', 'synteval_scripts', 'country_spec_scripts', 'EES2019_ro_synteval.R'))
+
+```
+
+Synthetic variables have been estimated for the full set of Romania parties available in the original 
+2019 EES Romanian voter study selected according to the criteria stated in the EES 2019 SDM codebook (
+for the criteria see Sect. XXX; for the relevant parties see Table \ref{table:relprty_tab_ro}). 
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+options(knitr.kable.NA = 'NA')
+options(knitr.table.format = "latex")
+
+names(relprty_df) <- c('Dep. Var.', 'Party', 'Party name (eng)')
+
+relprty_df %>% 
+  kable(caption = "Romanian relevant parties \\label{table:relprty_tab_ro}", booktabs = T, 
+        align = c('l', 'c', 'l')) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position'))
+
+```
+
+Full OLS models converge and coefficients do not show any particular issue (see Table 
+\ref{table:full_ols_ro}). 
+In terms of model fit, the adjusted coefficient of determination ($R^2$) values vary between 
+a minimum value of `r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==min(Adj_Rsq)) %>% .[['Adj_Rsq']]` 
+for party `r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==min(Adj_Rsq)) %>% .[['partycode']]` 
+(`r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==min(Adj_Rsq)) %>% .[['partyname_eng']]`) 
+and a maximum of `r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==max(Adj_Rsq)) %>% .[['Adj_Rsq']]`
+for party `r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==max(Adj_Rsq)) %>% .[['partycode']]`
+(`r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==max(Adj_Rsq)) %>% .[['partyname_eng']]`). 
+Moreover, the difference between Akaike Information Criterion (AIC) values for full OLS models and null 
+models shows that in 7 cases out of 7 null models perform better than full ones (see Table 
+\ref{table:ols_aic_ro}).
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+
+
+names(ols_aic) <- c('Dep. Var.', 'Party', 'Full Mod.', 'Null Mod.', 'Diff. (Full-Null)')
+
+ols_aic %>% 
+  kable(caption = "Akaike Information Criterion values for OLS full and null models 
+        \\label{table:ols_aic_ro}", booktabs = T, 
+        align = c('l', 'c', rep('r',3))) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position'))
+
+
+```
+
+On the contrary, one out of seven logistic regression models (see Table \ref{table:full_logit_ro}) show 
+inflated standard errors for some of the coefficients of interest: 
+
+* Model 12: EDU_rec, D6_une;
+
+It presents a problematic profile since the inflated standard errors affect the constant term.
+
+Model 12a inflated standard errors are due to separation issues. In short, no respondents with low 
+education and in unemployment did vote for party 2307 (see Tables \ref{table:crosstab_1_ro}, 
+\ref{table:crosstab_2_ro}). 
+
+As a consequence, a constrained version of model 12 (namely, Model 11b) without said variables was 
+estimated and contrasted with the original (Model 12a), full model. Likelihood-ratio test results show 
+that $H_0$ (namely, that the constrained model fits better than the full model) can be rejected at p<0.001
+(see Table \ref{table:lrtest_1_ro}). However, if just EDU_rec is dropped $H_0$ cannot be rejected 
+(see Table \ref{table:lrtest_2_ro}). Consequently, synthetic variables for respondents' vote choice for 
+party 2307 have been predicted relying on the constrained model where just EDU_rec is dropped (Model 12b). 
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+
+options(knitr.kable.NA = '')
+
+anova_lst2[[1]] %>%
+  kable(caption = "Likelihood-ratio Test between Model 12a (Unconstrained) and (Fully Constrained)
+                  \\label{table:lrtest_1_ro}", booktabs = F, ) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position'))
+
+anova_lst[[1]] %>%
+  kable(caption = "Likelihood-ratio Test between Model 12a (Unconstrained) and Model 12b (Constrained)
+                  \\label{table:lrtest_2_ro}", booktabs = F, ) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position'))
+
+```
+
+In terms of model fit, adjusted McFadden's pseudo $R^2$ values for the logistic full models vary between 
+a minimum value of 
+`r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==min(Adj_Ps_Rsq)) %>% .[['Adj_Ps_Rsq']] %>% round(.,3)` 
+for party `r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==min(Adj_Ps_Rsq)) %>% .[['partycode']]` 
+(`r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==min(Adj_Ps_Rsq)) %>% .[['partyname_eng']]`) 
+and a maximum of 
+`r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==max(Adj_Ps_Rsq)) %>% .[['Adj_Ps_Rsq']] %>% round(.,3)`
+for party `r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==max(Adj_Ps_Rsq)) %>% .[['partycode']]`
+(`r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==max(Adj_Ps_Rsq)) %>% .[['partyname_eng']]`). 
+Moreover, the difference between Akaike Information Criterion (AIC) values for logistic full models and 
+null models shows that in 3 cases out of 7 null models perform better than full ones. According to AIC 
+values the related null model appears to have a better fit than Model 12b (see Table
+\ref{table:logit_aic_ro}). 
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+
+logit_aic[7,1] <- 'stack_2307*'
+
+names(logit_aic) <- c('Dep. Var.', 'Party', 'Full Mod.', 'Null Mod.', 'Diff. (Full-Null)')
+
+logit_aic %>% 
+  kable(caption = "Akaike Information Criterion values for logistic full and null models 
+        \\label{table:logit_aic_ro}", booktabs = T, 
+        align = c('l', 'c', rep('r',3))) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position')) %>% 
+  footnote(symbol = 'AIC value refers to Model 12b (constrained).',
+           threeparttable = T,
+           footnote_as_chunk = T)
+```
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+
+options(knitr.kable.NA = 'NA')
+
+tabs[[1]] %>% 
+  kable(caption = "Cross tabulation between vote choice for party 505 and respondents' education 
+                   \\label{table:crosstab_1_ro}", booktabs = F) %>%  #  align = c('l', 'c', rep('r',3))
+  kable_styling(latex_options = c('striped'))
+
+tabs[[2]] %>% 
+  kable(caption = "Cross tabulation between vote choice for party 505 and respondents' employment
+                   \\label{table:crosstab_2_ro}", booktabs = F) %>% 
+  kable_styling(latex_options = c('striped'))
+
+
+```
+
+
+```{r, results='asis', echo=F}
+
+stargazer::stargazer(finalmod_lst$OLS, 
+                     title = "Propensity to vote for a relevant party according to respondents' 
+                     socio-demographic characteristics (OLS regression models)",
+                     label = 'table:full_ols_ro',
+                     type = 'latex',
+                     column.labels = c('2301', '2303', '2305', '2306', '2307', '2308', '2302'),
+                     dep.var.labels.include = F,
+                     star.cutoffs = c(0.05, 0.01, 0.001),
+                     omit.stat=c("f", "ser"),
+                     header = F,
+                     style = 'ajps')
+
+logit_regtab <- 
+  stargazer::stargazer(finalmod_lst$logit, 
+                       title = "Vote choice for a relevant party according to respondents' 
+                       socio-demographic characteristics (Logistic regression models)",
+                       label = 'table:full_logit_ro',
+                       type = 'latex',
+                       no.space = T, # to remove the spaces after each line of coefficients
+                       column.sep.width = '0.5pt', # to reduce column width
+                       font.size = 'small', # to make font size smaller
+                       column.labels = c('2301', '2303', '2305', '2306', '2307', '2307', '2308', '2302'),
+                       dep.var.labels.include = F,
+                       star.cutoffs = c(0.05, 0.01, 0.001),
+                       omit.stat=c("f", "ser"),
+                       header = F,
+                       style = 'ajps') %>% 
+  capture.output() 
+
+logit_regtab[9] %<>%
+  gsub('Model 8', 'Model 14',.) %>% 
+  gsub('Model 1$', 'Model 8',.) %>%
+  gsub('Model 7', 'Model 13',.) %>%
+  gsub('Model 6', 'Model 12b',.) %>% 
+  gsub('Model 5', 'Model 12a',.) %>% 
+  gsub('Model 4', 'Model 11',.) %>% 
+  gsub('Model 3', 'Model 10',.) %>% 
+  gsub('Model 2', 'Model 9',.) 
+
+cat(logit_regtab, sep = "\n")
+  
+
+```
+
+
+
+\newpage
+# Slovenia
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+# Source the Slovenian synteval script # - - - - - - - - - - - - - - - - - - - - - - - - - #
+
+source(here('Scripts', 'synteval_scripts', 'country_spec_scripts', 'EES2019_si_synteval.R'))
+
+```
+
+Synthetic variables have been estimated for the full set of Slovenian parties available in the original 
+2019 EES Slovenian voter study selected according to the criteria stated in the EES 2019 SDM codebook (
+for the criteria see Sect. XXX; for the relevant parties see Table \ref{table:relprty_tab_si}). 
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+options(knitr.kable.NA = 'NA')
+options(knitr.table.format = "latex")
+
+names(relprty_df) <- c('Dep. Var.', 'Party', 'Party name (eng)')
+
+relprty_df %>% 
+  kable(caption = "Slovenian relevant parties \\label{table:relprty_tab_si}", booktabs = T, 
+        align = c('l', 'c', 'l')) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position'))
+
+```
+
+Full OLS models converge and coefficients do not show any particular issue (see Table 
+\ref{table:full_ols_si}). 
+In terms of model fit, the adjusted coefficient of determination ($R^2$) values vary between 
+a minimum value of `r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==min(Adj_Rsq)) %>% .[['Adj_Rsq']]` 
+for party `r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==min(Adj_Rsq)) %>% .[['partycode']]` 
+(`r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==min(Adj_Rsq)) %>% .[['partyname_eng']]`) 
+and a maximum of `r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==max(Adj_Rsq)) %>% .[['Adj_Rsq']]`
+for party `r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==max(Adj_Rsq)) %>% .[['partycode']]`
+(`r ols_df %>% filter(model=='full') %>% filter(Adj_Rsq==max(Adj_Rsq)) %>% .[['partyname_eng']]`). 
+Moreover, the difference between Akaike Information Criterion (AIC) values for full OLS models and null 
+models shows that in 8 cases out of 9 null models perform better than full ones (see Table 
+\ref{table:ols_aic_si}).
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+
+
+names(ols_aic) <- c('Dep. Var.', 'Party', 'Full Mod.', 'Null Mod.', 'Diff. (Full-Null)')
+
+ols_aic %>% 
+  kable(caption = "Akaike Information Criterion values for OLS full and null models 
+        \\label{table:ols_aic_si}", booktabs = T, 
+        align = c('l', 'c', rep('r',3))) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position'))
+
+
+```
+
+On the contrary, three out of nine logistic regression models (see Tables \ref{table:full_logit_si_p1},
+\ref{table:full_logit_si_p2}) show inflated standard errors for some of the coefficients of interest, 
+in particular: 
+
+* Model 14: Edu_rec, D7_rec (category 2 only);
+* Model 16: D6_une;
+* Model 17: EDU_rec.
+
+Nevertheless, model 16 constant terms and other regression coefficients are not affected by said 
+inflated standard errors, whereas models 14a and 17a present a more problematic profile. 
+
+Model 14a inflated standard errors are due to separation issues. In short, no respondents with 
+low education and high subjective socioeconomic status (SES) did vote for party 2405 (see Tables \ref{table:crosstab_1_si}, 
+\ref{table:crosstab_2_si}). In Model 17a, no respondents with low education did cote for party 2408
+(see Table \ref{table:crosstab_3_si}).
+
+As a consequence, a constrained version of model 14 and 17 (namely, Model 14b,17b) without said variables was 
+estimated and contrasted with the original (Model 14a,17a), full model. Likelihood-ratio test results show 
+that in case of model 14 $H_0$ (namely, that the constrained model fits better than the full model) can be rejected 
+at p<0.001 (see Table \ref{table:lrtest_1_si}). However, if just EDU_rec is dropped $H_0$ can be rejected at p<0.1 
+(See Table \ref{table:lrtest_2_si}). For model 17 $H_0$ cannot be rejected (see Table \ref{table:lrtest_3_si}). 
+Consequently, synthetic variables for respondents' vote choice for party 2405 and 2408 both have been 
+predicted relying on the constrained model dropping EDU_rec (Model 14b,17b). 
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+
+options(knitr.kable.NA = '')
+
+anova_lst2[[1]] %>%
+  kable(caption = "Likelihood-ratio Test between Model 14a (Unconstrained) and (Fully Constrained)
+                  \\label{table:lrtest_1_si}", booktabs = F, ) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position'))
+
+anova_lst2[[1]] %>%
+  kable(caption = "Likelihood-ratio Test between Model 14a (Unconstrained) and Model 14b (Constrained)
+                  \\label{table:lrtest_2_si}", booktabs = F, ) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position'))
+
+anova_lst[[2]] %>%
+  kable(caption = "Likelihood-ratio Test between Model 17a (Unconstrained) and Model 17b (Constrained)
+                  \\label{table:lrtest_3_si}", booktabs = F, ) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position'))
+
+```
+
+In terms of model fit, adjusted McFadden's pseudo $R^2$ values for the logistic full models vary between 
+a minimum value of 
+`r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==min(Adj_Ps_Rsq)) %>% .[['Adj_Ps_Rsq']] %>% round(.,3)` 
+for party `r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==min(Adj_Ps_Rsq)) %>% .[['partycode']]` 
+(`r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==min(Adj_Ps_Rsq)) %>% .[['partyname_eng']]`) 
+and a maximum of 
+`r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==max(Adj_Ps_Rsq)) %>% .[['Adj_Ps_Rsq']] %>% round(.,3)`
+for party `r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==max(Adj_Ps_Rsq)) %>% .[['partycode']]`
+(`r logit_df %>% filter(model=='full') %>% filter(Adj_Ps_Rsq==max(Adj_Ps_Rsq)) %>% .[['partyname_eng']]`). 
+Moreover, the difference between Akaike Information Criterion (AIC) values for logistic full models and 
+null models shows that in 5 cases out of 9 null models perform better than full ones. According to AIC 
+values the related null model appears to have a better fit than Model 14b and 17b (see Table
+\ref{table:logit_aic_si}). 
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+
+logit_aic[1,1] <- 'stack_2408*'
+logit_aic[7,1] <- 'stack_2405*'
+
+names(logit_aic) <- c('Dep. Var.', 'Party', 'Full Mod.', 'Null Mod.', 'Diff. (Full-Null)')
+
+logit_aic %>% 
+  kable(caption = "Akaike Information Criterion values for logistic full and null models 
+        \\label{table:logit_aic_si}", booktabs = T, 
+        align = c('l', 'c', rep('r',3))) %>% 
+  kable_styling(latex_options = c('striped', 'hold_position')) %>% 
+  footnote(symbol = 'AIC value refers to Model 14b and 17b (constrained).',
+           threeparttable = T,
+           footnote_as_chunk = T)
+```
+
+```{r echo=FALSE, warning=FALSE, message=FALSE}
+
+options(knitr.kable.NA = 'NA')
+
+tabs[[1]] %>% 
+  kable(caption = "Cross tabulation between vote choice for party 2405 and respondents' education
+                   \\label{table:crosstab_1_si}", booktabs = F) %>%  #  align = c('l', 'c', rep('r',3))
+  kable_styling(latex_options = c('striped'))
+
+tabs[[2]] %>% 
+  kable(caption = "Cross tabulation between vote choice for party 2405 and respondents' subjective SES
+                   \\label{table:crosstab_2_si}", booktabs = F) %>% 
+  kable_styling(latex_options = c('striped'))
+
+tabs2[[1]] %>% 
+  kable(caption = "Cross tabulation between vote choice for party 2408 and respondents' education 
+                   \\label{table:crosstab_3_si}", booktabs = F) %>% 
+  kable_styling(latex_options = c('striped'))
+
+```
+
+
+```{r, results='asis', echo=F}
+
+stargazer::stargazer(finalmod_lst$OLS, 
+                     title = "Propensity to vote for a relevant party according to respondents' 
+                     socio-demographic characteristics (OLS regression models)",
+                     label = 'table:full_ols_si',
+                     type = 'latex',
+                     no.space = T, # to remove the spaces after each line of coefficients
+                     column.sep.width = '0.5pt', # to reduce column width
+                     font.size = 'footnotesize', # to make font size smaller
+                     column.labels = c('2401', '2402', '2403', '2404','2405', '2406', '2407', '2408', '2409'),
+                     dep.var.labels.include = F,
+                     star.cutoffs = c(0.05, 0.01, 0.001),
+                     omit.stat=c("f", "ser"),
+                     header = F,
+                     style = 'ajps')
+
+
+finalmod_lst2 <- finalmod_lst[["logit"]][-c(7,8,9,10,11)]
+finalmod_lst3 <- finalmod_lst[["logit"]][-c(1,2,3,4,5,6)]
+
+logit_regtab <- 
+  stargazer::stargazer(finalmod_lst2, 
+                       title = "Vote choice for a relevant party according to respondents' 
+                       socio-demographic characteristics (Logistic regression models)",
+                       label = 'table:full_logit_si_p1',
+                       type = 'latex',
+                       column.labels = c('2401', '2402', '2403', '2404', '2405', '2405'),
+                       dep.var.labels.include = F,
+                       star.cutoffs = c(0.05, 0.01, 0.001),
+                       omit.stat=c("f", "ser"),
+                       header = F,
+                       style = 'ajps') %>% 
+  capture.output() 
+
+logit_regtab2 <- 
+  stargazer::stargazer(finalmod_lst3, 
+                       title = "Vote choice for a relevant party according to respondents' 
+                       socio-demographic characteristics (Logistic regression models)",
+                       label = 'table:full_logit_si_p2',
+                       type = 'latex',
+                       column.labels = c('2406', '2407', '2408', '2408', '2409'),
+                       dep.var.labels.include = F,
+                       star.cutoffs = c(0.05, 0.01, 0.001),
+                       omit.stat=c("f", "ser"),
+                       header = F,
+                       style = 'ajps') %>% 
+  capture.output() 
+
+
+logit_regtab[9] %<>%
+  gsub('Model 1', 'Model 10',.) %>% 
+  gsub('Model 2', 'Model 11',.) %>% 
+  gsub('Model 3', 'Model 12',.) %>% 
+  gsub('Model 4', 'Model 13',.) %>% 
+  gsub('Model 5', 'Model 14a',.) %>% 
+  gsub('Model 6', 'Model 14b',.) 
+
+cat(logit_regtab, sep = "\n")
+
+logit_regtab2[9] %<>%
+  gsub('Model 1', 'Model 15',.) %>% 
+  gsub('Model 2', 'Model 16',.) %>% 
+  gsub('Model 3', 'Model 17a',.) %>% 
+  gsub('Model 4', 'Model 17b',.) %>% 
+  gsub('Model 5', 'Model 18',.) 
+
+cat(logit_regtab2, sep = "\n")
+  
+
+```
+
+
+
+
+
+
+
+
+

--- a/Docs/Synteval/scripts/EES2019_synteval_mk.log
+++ b/Docs/Synteval/scripts/EES2019_synteval_mk.log
@@ -1,0 +1,1032 @@
+This is pdfTeX, Version 3.141592653-2.6-1.40.23 (TeX Live 2022/dev) (preloaded format=pdflatex 2021.11.10)  12 NOV 2021 13:53
+entering extended mode
+ restricted \write18 enabled.
+ %&-line parsing enabled.
+**EES2019_synteval_mk.tex
+(./EES2019_synteval_mk.tex
+LaTeX2e <2021-06-01> patch level 1
+L3 programming layer <2021-10-18> (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/base/article.cls
+Document Class: article 2021/02/12 v1.4n Standard LaTeX document class
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/base/size10.clo
+File: size10.clo 2021/02/12 v1.4n Standard LaTeX file (size option)
+)
+\c@part=\count182
+\c@section=\count183
+\c@subsection=\count184
+\c@subsubsection=\count185
+\c@paragraph=\count186
+\c@subparagraph=\count187
+\c@figure=\count188
+\c@table=\count189
+\abovecaptionskip=\skip47
+\belowcaptionskip=\skip48
+\bibindent=\dimen138
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/lm/lmodern.sty
+Package: lmodern 2015/05/01 v1.6.1 Latin Modern Fonts
+LaTeX Font Info:    Overwriting symbol font `operators' in version `normal'
+(Font)                  OT1/cmr/m/n --> OT1/lmr/m/n on input line 22.
+LaTeX Font Info:    Overwriting symbol font `letters' in version `normal'
+(Font)                  OML/cmm/m/it --> OML/lmm/m/it on input line 23.
+LaTeX Font Info:    Overwriting symbol font `symbols' in version `normal'
+(Font)                  OMS/cmsy/m/n --> OMS/lmsy/m/n on input line 24.
+LaTeX Font Info:    Overwriting symbol font `largesymbols' in version `normal'
+(Font)                  OMX/cmex/m/n --> OMX/lmex/m/n on input line 25.
+LaTeX Font Info:    Overwriting symbol font `operators' in version `bold'
+(Font)                  OT1/cmr/bx/n --> OT1/lmr/bx/n on input line 26.
+LaTeX Font Info:    Overwriting symbol font `letters' in version `bold'
+(Font)                  OML/cmm/b/it --> OML/lmm/b/it on input line 27.
+LaTeX Font Info:    Overwriting symbol font `symbols' in version `bold'
+(Font)                  OMS/cmsy/b/n --> OMS/lmsy/b/n on input line 28.
+LaTeX Font Info:    Overwriting symbol font `largesymbols' in version `bold'
+(Font)                  OMX/cmex/m/n --> OMX/lmex/m/n on input line 29.
+LaTeX Font Info:    Overwriting math alphabet `\mathbf' in version `normal'
+(Font)                  OT1/cmr/bx/n --> OT1/lmr/bx/n on input line 31.
+LaTeX Font Info:    Overwriting math alphabet `\mathsf' in version `normal'
+(Font)                  OT1/cmss/m/n --> OT1/lmss/m/n on input line 32.
+LaTeX Font Info:    Overwriting math alphabet `\mathit' in version `normal'
+(Font)                  OT1/cmr/m/it --> OT1/lmr/m/it on input line 33.
+LaTeX Font Info:    Overwriting math alphabet `\mathtt' in version `normal'
+(Font)                  OT1/cmtt/m/n --> OT1/lmtt/m/n on input line 34.
+LaTeX Font Info:    Overwriting math alphabet `\mathbf' in version `bold'
+(Font)                  OT1/cmr/bx/n --> OT1/lmr/bx/n on input line 35.
+LaTeX Font Info:    Overwriting math alphabet `\mathsf' in version `bold'
+(Font)                  OT1/cmss/bx/n --> OT1/lmss/bx/n on input line 36.
+LaTeX Font Info:    Overwriting math alphabet `\mathit' in version `bold'
+(Font)                  OT1/cmr/bx/it --> OT1/lmr/bx/it on input line 37.
+LaTeX Font Info:    Overwriting math alphabet `\mathtt' in version `bold'
+(Font)                  OT1/cmtt/m/n --> OT1/lmtt/m/n on input line 38.
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/amsfonts/amssymb.sty
+Package: amssymb 2013/01/14 v3.01 AMS font symbols
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/amsfonts/amsfonts.sty
+Package: amsfonts 2013/01/14 v3.01 Basic AMSFonts support
+\@emptytoks=\toks16
+\symAMSa=\mathgroup4
+\symAMSb=\mathgroup5
+LaTeX Font Info:    Redeclaring math symbol \hbar on input line 98.
+LaTeX Font Info:    Overwriting math alphabet `\mathfrak' in version `bold'
+(Font)                  U/euf/m/n --> U/euf/b/n on input line 106.
+)) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/amsmath/amsmath.sty
+Package: amsmath 2021/04/20 v2.17j AMS math features
+\@mathmargin=\skip49
+For additional information on amsmath, use the `?' option.
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/amsmath/amstext.sty
+Package: amstext 2000/06/29 v2.01 AMS text
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/amsmath/amsgen.sty
+File: amsgen.sty 1999/11/30 v2.0 generic functions
+\@emptytoks=\toks17
+\ex@=\dimen139
+)) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/amsmath/amsbsy.sty
+Package: amsbsy 1999/11/29 v1.2d Bold Symbols
+\pmbraise@=\dimen140
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/amsmath/amsopn.sty
+Package: amsopn 2016/03/08 v2.02 operator names
+)
+\inf@bad=\count190
+LaTeX Info: Redefining \frac on input line 234.
+\uproot@=\count191
+\leftroot@=\count192
+LaTeX Info: Redefining \overline on input line 399.
+\classnum@=\count193
+\DOTSCASE@=\count194
+LaTeX Info: Redefining \ldots on input line 496.
+LaTeX Info: Redefining \dots on input line 499.
+LaTeX Info: Redefining \cdots on input line 620.
+\Mathstrutbox@=\box50
+\strutbox@=\box51
+\big@size=\dimen141
+LaTeX Font Info:    Redeclaring font encoding OML on input line 743.
+LaTeX Font Info:    Redeclaring font encoding OMS on input line 744.
+\macc@depth=\count195
+\c@MaxMatrixCols=\count196
+\dotsspace@=\muskip16
+\c@parentequation=\count197
+\dspbrk@lvl=\count198
+\tag@help=\toks18
+\row@=\count199
+\column@=\count266
+\maxfields@=\count267
+\andhelp@=\toks19
+\eqnshift@=\dimen142
+\alignsep@=\dimen143
+\tagshift@=\dimen144
+\tagwidth@=\dimen145
+\totwidth@=\dimen146
+\lineht@=\dimen147
+\@envbody=\toks20
+\multlinegap=\skip50
+\multlinetaggap=\skip51
+\mathdisplay@stack=\toks21
+LaTeX Info: Redefining \[ on input line 2923.
+LaTeX Info: Redefining \] on input line 2924.
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/generic/iftex/ifxetex.sty
+Package: ifxetex 2019/10/25 v0.7 ifxetex legacy package. Use iftex instead.
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/generic/iftex/iftex.sty
+Package: iftex 2020/03/06 v1.0d TeX engine tests
+)) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/generic/iftex/ifluatex.sty
+Package: ifluatex 2019/10/25 v1.5 ifluatex legacy package. Use iftex instead.
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/base/fixltx2e.sty
+Package: fixltx2e 2016/12/29 v2.1a fixes to LaTeX (obsolete)
+Applying: [2015/01/01] Old fixltx2e package on input line 46.
+
+Package fixltx2e Warning: fixltx2e is not required with releases after 2015
+(fixltx2e)                All fixes are now in the LaTeX kernel.
+(fixltx2e)                See the latexrelease package for details.
+
+Already applied: [0000/00/00] Old fixltx2e package on input line 53.
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/base/fontenc.sty
+Package: fontenc 2021/04/29 v2.0v Standard LaTeX package
+LaTeX Font Info:    Trying to load font information for T1+lmr on input line 112.
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/lm/t1lmr.fd
+File: t1lmr.fd 2015/05/01 v1.6.1 Font defs for Latin Modern
+)) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/base/inputenc.sty
+Package: inputenc 2021/02/14 v1.3d Input encoding file
+\inpenc@prehook=\toks22
+\inpenc@posthook=\toks23
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/base/textcomp.sty
+Package: textcomp 2020/02/02 v2.0n Standard LaTeX package
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/xcolor/xcolor.sty
+Package: xcolor 2021/10/31 v2.13 LaTeX color extensions (UK)
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/graphics-cfg/color.cfg
+File: color.cfg 2016/01/02 v1.6 sample color configuration
+)
+Package xcolor Info: Driver file: pdftex.def on input line 227.
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/graphics-def/pdftex.def
+File: pdftex.def 2020/10/05 v1.2a Graphics/color driver for pdftex
+)
+Package xcolor Info: Model `cmy' substituted by `cmy0' on input line 1352.
+Package xcolor Info: Model `hsb' substituted by `rgb' on input line 1356.
+Package xcolor Info: Model `RGB' extended on input line 1368.
+Package xcolor Info: Model `HTML' substituted by `rgb' on input line 1370.
+Package xcolor Info: Model `Hsb' substituted by `hsb' on input line 1371.
+Package xcolor Info: Model `tHsb' substituted by `hsb' on input line 1372.
+Package xcolor Info: Model `HSB' substituted by `hsb' on input line 1373.
+Package xcolor Info: Model `Gray' substituted by `gray' on input line 1374.
+Package xcolor Info: Model `wave' substituted by `hsb' on input line 1375.
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/graphics/dvipsnam.def
+File: dvipsnam.def 2016/06/17 v3.0m Driver-dependent file (DPC,SPQR)
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/xcolor/svgnam.def
+File: svgnam.def 2021/10/31 v2.13 Predefined colors according to SVG 1.1 (UK)
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/xcolor/x11nam.def
+File: x11nam.def 2021/10/31 v2.13 Predefined colors according to Unix/X11 (UK)
+)) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/hyperref/hyperref.sty
+Package: hyperref 2021-06-07 v7.00m Hypertext links for LaTeX
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/generic/ltxcmds/ltxcmds.sty
+Package: ltxcmds 2020-05-10 v1.25 LaTeX kernel commands for general use (HO)
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/generic/pdftexcmds/pdftexcmds.sty
+Package: pdftexcmds 2020-06-27 v0.33 Utility functions of pdfTeX for LuaTeX (HO)
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/generic/infwarerr/infwarerr.sty
+Package: infwarerr 2019/12/03 v1.5 Providing info/warning/error messages (HO)
+)
+Package pdftexcmds Info: \pdf@primitive is available.
+Package pdftexcmds Info: \pdf@ifprimitive is available.
+Package pdftexcmds Info: \pdfdraftmode found.
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/graphics/keyval.sty
+Package: keyval 2014/10/28 v1.15 key=value parser (DPC)
+\KV@toks@=\toks24
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/generic/kvsetkeys/kvsetkeys.sty
+Package: kvsetkeys 2019/12/15 v1.18 Key value parser (HO)
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/generic/kvdefinekeys/kvdefinekeys.sty
+Package: kvdefinekeys 2019-12-19 v1.6 Define keys (HO)
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/generic/pdfescape/pdfescape.sty
+Package: pdfescape 2019/12/09 v1.15 Implements pdfTeX's escape features (HO)
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/hycolor/hycolor.sty
+Package: hycolor 2020-01-27 v1.10 Color options for hyperref/bookmark (HO)
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/letltxmacro/letltxmacro.sty
+Package: letltxmacro 2019/12/03 v1.6 Let assignment for LaTeX macros (HO)
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/auxhook/auxhook.sty
+Package: auxhook 2019-12-17 v1.6 Hooks for auxiliary files (HO)
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/kvoptions/kvoptions.sty
+Package: kvoptions 2020-10-07 v3.14 Key value format for package options (HO)
+)
+\@linkdim=\dimen148
+\Hy@linkcounter=\count268
+\Hy@pagecounter=\count269
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/hyperref/pd1enc.def
+File: pd1enc.def 2021-06-07 v7.00m Hyperref: PDFDocEncoding definition (HO)
+Now handling font encoding PD1 ...
+... no UTF-8 mapping file for font encoding PD1
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/hyperref/hyperref-langpatches.def
+File: hyperref-langpatches.def 2021-06-07 v7.00m Hyperref: patches for babel languages
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/generic/intcalc/intcalc.sty
+Package: intcalc 2019/12/15 v1.3 Expandable calculations with integers (HO)
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/generic/etexcmds/etexcmds.sty
+Package: etexcmds 2019/12/15 v1.7 Avoid name clashes with e-TeX commands (HO)
+)
+\Hy@SavedSpaceFactor=\count270
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/hyperref/puenc.def
+File: puenc.def 2021-06-07 v7.00m Hyperref: PDF Unicode definition (HO)
+Now handling font encoding PU ...
+... no UTF-8 mapping file for font encoding PU
+)
+Package hyperref Info: Option `unicode' set `true' on input line 4073.
+Package hyperref Info: Hyper figures OFF on input line 4192.
+Package hyperref Info: Link nesting OFF on input line 4197.
+Package hyperref Info: Hyper index ON on input line 4200.
+Package hyperref Info: Plain pages OFF on input line 4207.
+Package hyperref Info: Backreferencing OFF on input line 4212.
+Package hyperref Info: Implicit mode ON; LaTeX internals redefined.
+Package hyperref Info: Bookmarks ON on input line 4445.
+\c@Hy@tempcnt=\count271
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/url/url.sty
+\Urlmuskip=\muskip17
+Package: url 2013/09/16  ver 3.4  Verb mode for urls, etc.
+)
+LaTeX Info: Redefining \url on input line 4804.
+\XeTeXLinkMargin=\dimen149
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/generic/bitset/bitset.sty
+Package: bitset 2019/12/09 v1.3 Handle bit-vector datatype (HO)
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/generic/bigintcalc/bigintcalc.sty
+Package: bigintcalc 2019/12/15 v1.5 Expandable calculations on big integers (HO)
+))
+\Fld@menulength=\count272
+\Field@Width=\dimen150
+\Fld@charsize=\dimen151
+Package hyperref Info: Hyper figures OFF on input line 6076.
+Package hyperref Info: Link nesting OFF on input line 6081.
+Package hyperref Info: Hyper index ON on input line 6084.
+Package hyperref Info: backreferencing OFF on input line 6091.
+Package hyperref Info: Link coloring OFF on input line 6096.
+Package hyperref Info: Link coloring with OCG OFF on input line 6101.
+Package hyperref Info: PDF/A mode OFF on input line 6106.
+LaTeX Info: Redefining \ref on input line 6146.
+LaTeX Info: Redefining \pageref on input line 6150.
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/base/atbegshi-ltx.sty
+Package: atbegshi-ltx 2021/01/10 v1.0c Emulation of the original atbegshi
+package with kernel methods
+)
+\Hy@abspage=\count273
+\c@Item=\count274
+\c@Hfootnote=\count275
+)
+Package hyperref Info: Driver (autodetected): hpdftex.
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/hyperref/hpdftex.def
+File: hpdftex.def 2021-06-07 v7.00m Hyperref driver for pdfTeX
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/base/atveryend-ltx.sty
+Package: atveryend-ltx 2020/08/19 v1.0a Emulation of the original atvery package
+with kernel methods
+)
+\Fld@listcount=\count276
+\c@bookmark@seq@number=\count277
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/rerunfilecheck/rerunfilecheck.sty
+Package: rerunfilecheck 2019/12/05 v1.9 Rerun checks for auxiliary files (HO)
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/generic/uniquecounter/uniquecounter.sty
+Package: uniquecounter 2019/12/15 v1.4 Provide unlimited unique counter (HO)
+)
+Package uniquecounter Info: New unique counter `rerunfilecheck' on input line 286.
+)
+\Hy@SectionHShift=\skip52
+)
+Package hyperref Info: Option `colorlinks' set `true' on input line 41.
+Package hyperref Info: Option `breaklinks' set `true' on input line 41.
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/geometry/geometry.sty
+Package: geometry 2020/01/02 v5.9 Page Geometry
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/generic/iftex/ifvtex.sty
+Package: ifvtex 2019/10/25 v1.7 ifvtex legacy package. Use iftex instead.
+)
+\Gm@cnth=\count278
+\Gm@cntv=\count279
+\c@Gm@tempcnt=\count280
+\Gm@bindingoffset=\dimen152
+\Gm@wd@mp=\dimen153
+\Gm@odd@mp=\dimen154
+\Gm@even@mp=\dimen155
+\Gm@layoutwidth=\dimen156
+\Gm@layoutheight=\dimen157
+\Gm@layouthoffset=\dimen158
+\Gm@layoutvoffset=\dimen159
+\Gm@dimlist=\toks25
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/tools/longtable.sty
+Package: longtable 2021-05-07 v4.16 Multi-page Table package (DPC)
+\LTleft=\skip53
+\LTright=\skip54
+\LTpre=\skip55
+\LTpost=\skip56
+\LTchunksize=\count281
+\LTcapwidth=\dimen160
+\LT@head=\box52
+\LT@firsthead=\box53
+\LT@foot=\box54
+\LT@lastfoot=\box55
+\LT@gbox=\box56
+\LT@cols=\count282
+\LT@rows=\count283
+\c@LT@tables=\count284
+\c@LT@chunks=\count285
+\LT@p@ftn=\toks26
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/booktabs/booktabs.sty
+Package: booktabs 2020/01/12 v1.61803398 Publication quality tables
+\heavyrulewidth=\dimen161
+\lightrulewidth=\dimen162
+\cmidrulewidth=\dimen163
+\belowrulesep=\dimen164
+\belowbottomsep=\dimen165
+\aboverulesep=\dimen166
+\abovetopsep=\dimen167
+\cmidrulesep=\dimen168
+\cmidrulekern=\dimen169
+\defaultaddspace=\dimen170
+\@cmidla=\count286
+\@cmidlb=\count287
+\@aboverulesep=\dimen171
+\@belowrulesep=\dimen172
+\@thisruleclass=\count288
+\@lastruleclass=\count289
+\@thisrulewidth=\dimen173
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/mdwtools/footnote.sty
+Package: footnote 1997/01/28 1.13 Save footnotes around boxes
+\fn@notes=\box57
+\fn@width=\dimen174
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/graphics/graphicx.sty
+Package: graphicx 2020/12/05 v1.2c Enhanced LaTeX Graphics (DPC,SPQR)
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/graphics/graphics.sty
+Package: graphics 2021/03/04 v1.4d Standard LaTeX Graphics (DPC,SPQR)
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/graphics/trig.sty
+Package: trig 2016/01/03 v1.10 sin cos tan (DPC)
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/graphics-cfg/graphics.cfg
+File: graphics.cfg 2016/06/04 v1.11 sample graphics configuration
+)
+Package graphics Info: Driver file: pdftex.def on input line 107.
+)
+\Gin@req@height=\dimen175
+\Gin@req@width=\dimen176
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/grffile/grffile.sty
+Package: grffile 2019/11/11 v2.1 Extended file name support for graphics (legacy)
+Package grffile Info: This package is an empty stub for compatibility on input line 40.
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/graphics/lscape.sty
+Package: lscape 2020/05/28 v3.02 Landscape Pages (DPC)
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/float/float.sty
+Package: float 2001/11/08 v1.3d Float enhancements (AL)
+\c@float@type=\count290
+\float@exts=\toks27
+\float@box=\box58
+\@float@everytoks=\toks28
+\@floatcapt=\box59
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/tools/afterpage.sty
+Package: afterpage 2014/10/28 v1.08 After-Page Package (DPC)
+\AP@output=\toks29
+\AP@partial=\box60
+\AP@footins=\box61
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/setspace/setspace.sty
+Package: setspace 2011/12/19 v6.7a set line spacing
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/etoolbox/etoolbox.sty
+Package: etoolbox 2020/10/05 v2.5k e-TeX tools for LaTeX (JAW)
+\etb@tempcnta=\count291
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/tools/array.sty
+Package: array 2021/04/20 v2.5e Tabular extension package (FMi)
+\col@sep=\dimen177
+\ar@mcellbox=\box62
+\extrarowheight=\dimen178
+\NC@list=\toks30
+\extratabsurround=\skip57
+\backup@length=\skip58
+\ar@cellbox=\box63
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/multirow/multirow.sty
+Package: multirow 2021/03/15 v2.8 Span multiple rows of a table
+\multirow@colwidth=\skip59
+\multirow@cntb=\count292
+\multirow@dima=\skip60
+\bigstrutjot=\dimen179
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/wrapfig/wrapfig.sty
+\wrapoverhang=\dimen180
+\WF@size=\dimen181
+\c@WF@wrappedlines=\count293
+\WF@box=\box64
+\WF@everypar=\toks31
+Package: wrapfig 2003/01/31  v 3.6
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/colortbl/colortbl.sty
+Package: colortbl 2020/01/04 v1.0e Color table columns (DPC)
+\everycr=\toks32
+\minrowclearance=\skip61
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/pdflscape/pdflscape.sty
+Package: pdflscape 2019/12/05 v0.12 Display of landscape pages in PDF (HO)
+Package pdflscape Info: Auto-detected driver: pdftex on input line 81.
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/tabu/tabu.sty
+Package: tabu 2019/01/11 v2.9 - flexible LaTeX tabulars (FC+tabu-fixed)
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/varwidth/varwidth.sty
+Package: varwidth 2009/03/30 ver 0.92;  Variable-width minipages
+\@vwid@box=\box65
+\sift@deathcycles=\count294
+\@vwid@loff=\dimen182
+\@vwid@roff=\dimen183
+)
+\c@taburow=\count295
+\tabu@nbcols=\count296
+\tabu@cnt=\count297
+\tabu@Xcol=\count298
+\tabu@alloc=\count299
+\tabu@nested=\count300
+\tabu@target=\dimen184
+\tabu@spreadtarget=\dimen185
+\tabu@naturalX=\dimen186
+\tabucolX=\dimen187
+\tabu@Xsum=\dimen188
+\extrarowdepth=\dimen189
+\abovetabulinesep=\dimen190
+\belowtabulinesep=\dimen191
+\tabustrutrule=\dimen192
+\tabu@thebody=\toks33
+\tabu@footnotes=\toks34
+\tabu@box=\box66
+\tabu@arstrutbox=\box67
+\tabu@hleads=\box68
+\tabu@vleads=\box69
+\tabu@cellskip=\skip62
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/threeparttable/threeparttable.sty
+Package: threeparttable 2003/06/13  v 3.0
+\@tempboxb=\box70
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/threeparttablex/threeparttablex.sty
+Package: threeparttablex 2013/07/23 v0.3 by daleif
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/environ/environ.sty
+Package: environ 2014/05/04 v0.3 A new way to define environments
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/trimspaces/trimspaces.sty
+Package: trimspaces 2009/09/17 v1.1 Trim spaces around a token list
+))
+\TPTL@width=\skip63
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/generic/ulem/ulem.sty
+\UL@box=\box71
+\UL@hyphenbox=\box72
+\UL@skip=\skip64
+\UL@hook=\toks35
+\UL@height=\dimen193
+\UL@pe=\count301
+\UL@pixel=\dimen194
+\ULC@box=\box73
+Package: ulem 2019/11/18
+\ULdepth=\dimen195
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/makecell/makecell.sty
+Package: makecell 2009/08/03 V0.1e Managing of Tab Column Heads and Cells
+\rotheadsize=\dimen196
+\c@nlinenum=\count302
+\TeXr@lab=\toks36
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/l3backend/l3backend-pdftex.def
+File: l3backend-pdftex.def 2021-10-18 L3 backend support: PDF output (pdfTeX)
+\l__color_backend_stack_int=\count303
+\l__pdf_internal_box=\box74
+) (./EES2019_synteval_mk.aux
+
+LaTeX Warning: Label `tab:unnamed-chunk-7' multiply defined.
+
+
+LaTeX Warning: Label `tab:unnamed-chunk-12' multiply defined.
+
+
+LaTeX Warning: Label `tab:unnamed-chunk-14' multiply defined.
+
+
+LaTeX Warning: Label `tab:unnamed-chunk-14' multiply defined.
+
+
+LaTeX Warning: Label `tab:unnamed-chunk-14' multiply defined.
+
+
+LaTeX Warning: Label `tab:unnamed-chunk-14' multiply defined.
+
+
+LaTeX Warning: Label `tab:unnamed-chunk-14' multiply defined.
+
+
+LaTeX Warning: Label `tab:unnamed-chunk-14' multiply defined.
+
+
+LaTeX Warning: Label `tab:unnamed-chunk-31' multiply defined.
+
+
+LaTeX Warning: Label `tab:unnamed-chunk-31' multiply defined.
+
+
+LaTeX Warning: Label `tab:unnamed-chunk-31' multiply defined.
+
+
+LaTeX Warning: Label `tab:unnamed-chunk-31' multiply defined.
+
+
+LaTeX Warning: Label `tab:unnamed-chunk-33' multiply defined.
+
+
+LaTeX Warning: Label `tab:unnamed-chunk-33' multiply defined.
+
+
+LaTeX Warning: Label `tab:unnamed-chunk-33' multiply defined.
+
+
+LaTeX Warning: Label `tab:unnamed-chunk-33' multiply defined.
+
+
+LaTeX Warning: Label `tab:unnamed-chunk-33' multiply defined.
+
+
+LaTeX Warning: Label `tab:unnamed-chunk-38' multiply defined.
+
+
+LaTeX Warning: Label `tab:unnamed-chunk-40' multiply defined.
+
+
+LaTeX Warning: Label `tab:unnamed-chunk-45' multiply defined.
+
+
+LaTeX Warning: Label `tab:unnamed-chunk-45' multiply defined.
+
+
+LaTeX Warning: Label `tab:unnamed-chunk-47' multiply defined.
+
+
+LaTeX Warning: Label `tab:unnamed-chunk-47' multiply defined.
+
+)
+\openout1 = `EES2019_synteval_mk.aux'.
+
+LaTeX Font Info:    Checking defaults for OML/cmm/m/it on input line 131.
+LaTeX Font Info:    ... okay on input line 131.
+LaTeX Font Info:    Checking defaults for OMS/cmsy/m/n on input line 131.
+LaTeX Font Info:    ... okay on input line 131.
+LaTeX Font Info:    Checking defaults for OT1/cmr/m/n on input line 131.
+LaTeX Font Info:    ... okay on input line 131.
+LaTeX Font Info:    Checking defaults for T1/cmr/m/n on input line 131.
+LaTeX Font Info:    ... okay on input line 131.
+LaTeX Font Info:    Checking defaults for TS1/cmr/m/n on input line 131.
+LaTeX Font Info:    ... okay on input line 131.
+LaTeX Font Info:    Checking defaults for OMX/cmex/m/n on input line 131.
+LaTeX Font Info:    ... okay on input line 131.
+LaTeX Font Info:    Checking defaults for U/cmr/m/n on input line 131.
+LaTeX Font Info:    ... okay on input line 131.
+LaTeX Font Info:    Checking defaults for PD1/pdf/m/n on input line 131.
+LaTeX Font Info:    ... okay on input line 131.
+LaTeX Font Info:    Checking defaults for PU/pdf/m/n on input line 131.
+LaTeX Font Info:    ... okay on input line 131.
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/epstopdf-pkg/epstopdf-base.sty
+Package: epstopdf-base 2020-01-24 v2.11 Base part for package epstopdf
+Package epstopdf-base Info: Redefining graphics rule for `.eps' on input line 485.
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/latexconfig/epstopdf-sys.cfg
+File: epstopdf-sys.cfg 2010/07/13 v1.3 Configuration of (r)epstopdf for TeX Live
+))
+Package hyperref Info: Link coloring ON on input line 131.
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/hyperref/nameref.sty
+Package: nameref 2021-04-02 v2.47 Cross-referencing by name of section
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/refcount/refcount.sty
+Package: refcount 2019/12/15 v3.6 Data extraction from label references (HO)
+) (/Users/matthias/Library/TinyTeX/texmf-dist/tex/generic/gettitlestring/gettitlestring.sty
+Package: gettitlestring 2019/12/15 v1.6 Cleanup title references (HO)
+)
+\c@section@level=\count304
+)
+LaTeX Info: Redefining \ref on input line 131.
+LaTeX Info: Redefining \pageref on input line 131.
+LaTeX Info: Redefining \nameref on input line 131.
+(./EES2019_synteval_mk.out) (./EES2019_synteval_mk.out)
+\@outlinefile=\write3
+\openout3 = `EES2019_synteval_mk.out'.
+
+*geometry* driver: auto-detecting
+*geometry* detected driver: pdftex
+*geometry* verbose mode - [ preamble ] result:
+* driver: pdftex
+* paper: <default>
+* layout: <same size as paper>
+* layoutoffset:(h,v)=(0.0pt,0.0pt)
+* modes: 
+* h-part:(L,W,R)=(72.26999pt, 469.75502pt, 72.26999pt)
+* v-part:(T,H,B)=(72.26999pt, 650.43001pt, 72.26999pt)
+* \paperwidth=614.295pt
+* \paperheight=794.96999pt
+* \textwidth=469.75502pt
+* \textheight=650.43001pt
+* \oddsidemargin=0.0pt
+* \evensidemargin=0.0pt
+* \topmargin=-37.0pt
+* \headheight=12.0pt
+* \headsep=25.0pt
+* \topskip=10.0pt
+* \footskip=30.0pt
+* \marginparwidth=65.0pt
+* \marginparsep=11.0pt
+* \columnsep=10.0pt
+* \skip\footins=9.0pt plus 4.0pt minus 2.0pt
+* \hoffset=0.0pt
+* \voffset=0.0pt
+* \mag=1000
+* \@twocolumnfalse
+* \@twosidefalse
+* \@mparswitchfalse
+* \@reversemarginfalse
+* (1in=72.27pt=25.4mm, 1cm=28.453pt)
+
+LaTeX Font Info:    Trying to load font information for OT1+lmr on input line 133.
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/lm/ot1lmr.fd
+File: ot1lmr.fd 2015/05/01 v1.6.1 Font defs for Latin Modern
+)
+LaTeX Font Info:    Trying to load font information for OML+lmm on input line 133.
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/lm/omllmm.fd
+File: omllmm.fd 2015/05/01 v1.6.1 Font defs for Latin Modern
+)
+LaTeX Font Info:    Trying to load font information for OMS+lmsy on input line 133.
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/lm/omslmsy.fd
+File: omslmsy.fd 2015/05/01 v1.6.1 Font defs for Latin Modern
+)
+LaTeX Font Info:    Trying to load font information for OMX+lmex on input line 133.
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/lm/omxlmex.fd
+File: omxlmex.fd 2015/05/01 v1.6.1 Font defs for Latin Modern
+)
+LaTeX Font Info:    External font `lmex10' loaded for size
+(Font)              <12> on input line 133.
+LaTeX Font Info:    External font `lmex10' loaded for size
+(Font)              <8> on input line 133.
+LaTeX Font Info:    External font `lmex10' loaded for size
+(Font)              <6> on input line 133.
+LaTeX Font Info:    Trying to load font information for U+msa on input line 133.
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/amsfonts/umsa.fd
+File: umsa.fd 2013/01/14 v3.01 AMS symbols A
+)
+LaTeX Font Info:    Trying to load font information for U+msb on input line 133.
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/amsfonts/umsb.fd
+File: umsb.fd 2013/01/14 v3.01 AMS symbols B
+) [1
+
+{/Users/matthias/Library/TinyTeX/texmf-var/fonts/map/pdftex/updmap/pdftex.map}]
+LaTeX Font Info:    External font `lmex10' loaded for size
+(Font)              <10> on input line 147.
+LaTeX Font Info:    External font `lmex10' loaded for size
+(Font)              <7> on input line 147.
+LaTeX Font Info:    External font `lmex10' loaded for size
+(Font)              <5> on input line 147.
+LaTeX Font Info:    Trying to load font information for TS1+lmr on input line 201.
+(/Users/matthias/Library/TinyTeX/texmf-dist/tex/latex/lm/ts1lmr.fd
+File: ts1lmr.fd 2015/05/01 v1.6.1 Font defs for Latin Modern
+) [2pdfTeX warning (ext4): destination with the same identifier (name{table.1.1}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.230 \end{table}
+                 pdfTeX warning (ext4): destination with the same identifier (name{table.1.2}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.230 \end{table}
+                 ] [3pdfTeX warning (ext4): destination with the same identifier (name{table.1.3}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.391 \newpage
+              pdfTeX warning (ext4): destination with the same identifier (name{table.1.4}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.391 \newpage
+              pdfTeX warning (ext4): destination with the same identifier (name{table.1.5}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.391 \newpage
+              ] [4pdfTeX warning (ext4): destination with the same identifier (name{table.1.6}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.391 \newpage
+              pdfTeX warning (ext4): destination with the same identifier (name{table.1.7}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.391 \newpage
+              ] [5pdfTeX warning (ext4): destination with the same identifier (name{table.1.8}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.391 \newpage
+              ]
+Overfull \hbox (36.18898pt too wide) in paragraph at lines 404--418
+ [][] 
+ []
+
+[6pdfTeX warning (ext4): destination with the same identifier (name{table.2.1}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.471 A
+       s a consequence, a constrained version of model 8 and 13 (namely, Mod...pdfTeX warning (ext4): destination with the same identifier (name{table.2.2}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.471 A
+       s a consequence, a constrained version of model 8 and 13 (namely, Mod...]
+Overfull \hbox (22.27405pt too wide) in paragraph at lines 695--730
+ [][] 
+ []
+
+
+Overfull \hbox (49.0187pt too wide) in paragraph at lines 737--772
+ [][] 
+ []
+
+[7pdfTeX warning (ext4): destination with the same identifier (name{table.2.3}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.774 \newpage
+              pdfTeX warning (ext4): destination with the same identifier (name{table.2.4}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.774 \newpage
+              pdfTeX warning (ext4): destination with the same identifier (name{table.2.5}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.774 \newpage
+              ] [8pdfTeX warning (ext4): destination with the same identifier (name{table.2.6}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.774 \newpage
+              pdfTeX warning (ext4): destination with the same identifier (name{table.2.7}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.774 \newpage
+              pdfTeX warning (ext4): destination with the same identifier (name{table.2.8}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.774 \newpage
+              pdfTeX warning (ext4): destination with the same identifier (name{table.2.9}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.774 \newpage
+              pdfTeX warning (ext4): destination with the same identifier (name{table.2.10}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.774 \newpage
+              pdfTeX warning (ext4): destination with the same identifier (name{table.2.11}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.774 \newpage
+              ] [9pdfTeX warning (ext4): destination with the same identifier (name{table.2.12}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.774 \newpage
+              pdfTeX warning (ext4): destination with the same identifier (name{table.2.13}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.774 \newpage
+              ] [10pdfTeX warning (ext4): destination with the same identifier (name{table.2.14}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.774 \newpage
+              ]
+
+LaTeX Warning: `!h' float specifier changed to `!ht'.
+
+
+Overfull \hbox (18.42804pt too wide) in paragraph at lines 875--910
+ [][] 
+ []
+
+
+Overfull \hbox (43.08846pt too wide) in paragraph at lines 916--951
+ [][] 
+ []
+
+[11pdfTeX warning (ext4): destination with the same identifier (name{table.3.1}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.953 \newpage
+              pdfTeX warning (ext4): destination with the same identifier (name{table.3.2}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.953 \newpage
+              ] [12pdfTeX warning (ext4): destination with the same identifier (name{table.3.3}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.980 \end{table}
+                 pdfTeX warning (ext4): destination with the same identifier (name{table.3.4}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.980 \end{table}
+                 ] [13pdfTeX warning (ext4): destination with the same identifier (name{table.3.5}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.980 \end{table}
+                 ]
+
+LaTeX Warning: `!h' float specifier changed to `!ht'.
+
+[14pdfTeX warning (ext4): destination with the same identifier (name{table.4.1}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1089 \end{table}
+                  pdfTeX warning (ext4): destination with the same identifier (name{table.4.2}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1089 \end{table}
+                  ]
+Overfull \hbox (43.78525pt too wide) in paragraph at lines 1156--1191
+ [][] 
+ []
+
+[15pdfTeX warning (ext4): destination with the same identifier (name{table.4.3}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1193 \newpage
+               pdfTeX warning (ext4): destination with the same identifier (name{table.4.4}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1193 \newpage
+               pdfTeX warning (ext4): destination with the same identifier (name{table.4.5}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1193 \newpage
+               ] [16pdfTeX warning (ext4): destination with the same identifier (name{table.4.6}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1193 \newpage
+               ] [17pdfTeX warning (ext4): destination with the same identifier (name{table.4.7}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1193 \newpage
+               ] [18pdfTeX warning (ext4): destination with the same identifier (name{table.5.1}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1279 
+       pdfTeX warning (ext4): destination with the same identifier (name{table.5.2}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1279 
+       ]
+
+LaTeX Warning: `!h' float specifier changed to `!ht'.
+
+[19pdfTeX warning (ext4): destination with the same identifier (name{table.5.3}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1391 
+       pdfTeX warning (ext4): destination with the same identifier (name{table.5.4}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1391 
+       pdfTeX warning (ext4): destination with the same identifier (name{table.5.5}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1391 
+       pdfTeX warning (ext4): destination with the same identifier (name{table.5.6}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1391 
+       ]
+Overfull \hbox (14.58203pt too wide) in paragraph at lines 1547--1582
+ [][] 
+ []
+
+[20pdfTeX warning (ext4): destination with the same identifier (name{table.5.7}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1666 \newpage
+               pdfTeX warning (ext4): destination with the same identifier (name{table.5.8}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1666 \newpage
+               pdfTeX warning (ext4): destination with the same identifier (name{table.5.9}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1666 \newpage
+               ] [21pdfTeX warning (ext4): destination with the same identifier (name{table.5.10}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1666 \newpage
+               pdfTeX warning (ext4): destination with the same identifier (name{table.5.11}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1666 \newpage
+               pdfTeX warning (ext4): destination with the same identifier (name{table.5.12}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1666 \newpage
+               pdfTeX warning (ext4): destination with the same identifier (name{table.5.13}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1666 \newpage
+               pdfTeX warning (ext4): destination with the same identifier (name{table.5.14}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1666 \newpage
+               ] [22pdfTeX warning (ext4): destination with the same identifier (name{table.5.15}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1666 \newpage
+               ] [23pdfTeX warning (ext4): destination with the same identifier (name{table.5.16}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1666 \newpage
+               ] [24pdfTeX warning (ext4): destination with the same identifier (name{table.5.17}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1666 \newpage
+               ] [25pdfTeX warning (ext4): destination with the same identifier (name{table.6.1}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1750 
+       pdfTeX warning (ext4): destination with the same identifier (name{table.6.2}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1750 
+       ]
+Overfull \hbox (16.50504pt too wide) in paragraph at lines 1868--1903
+ [][] 
+ []
+
+LaTeX Font Info:    External font `lmex10' loaded for size
+(Font)              <9> on input line 1910.
+
+Overfull \hbox (14.87778pt too wide) in paragraph at lines 1910--1945
+ [][] 
+ []
+
+[26pdfTeX warning (ext4): destination with the same identifier (name{table.6.3}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1947 \newpage
+               pdfTeX warning (ext4): destination with the same identifier (name{table.6.4}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1947 \newpage
+               pdfTeX warning (ext4): destination with the same identifier (name{table.6.5}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1947 \newpage
+               ] [27pdfTeX warning (ext4): destination with the same identifier (name{table.6.6}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1947 \newpage
+               pdfTeX warning (ext4): destination with the same identifier (name{table.6.7}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1947 \newpage
+               pdfTeX warning (ext4): destination with the same identifier (name{table.6.8}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1947 \newpage
+               ] [28pdfTeX warning (ext4): destination with the same identifier (name{table.6.9}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.1947 \newpage
+               ] [29pdfTeX warning (ext4): destination with the same identifier (name{table.7.1}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.2031 M
+        odel 14a inflated standard errors are due to separation issues. In s...pdfTeX warning (ext4): destination with the same identifier (name{table.7.2}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.2031 M
+        odel 14a inflated standard errors are due to separation issues. In s...]
+
+LaTeX Warning: `!h' float specifier changed to `!ht'.
+
+
+Overfull \hbox (26.15018pt too wide) in paragraph at lines 2202--2237
+ [][] 
+ []
+
+[30pdfTeX warning (ext4): destination with the same identifier (name{table.7.3}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.2321 \end{document}
+                     pdfTeX warning (ext4): destination with the same identifier (name{table.7.4}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.2321 \end{document}
+                     pdfTeX warning (ext4): destination with the same identifier (name{table.7.5}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.2321 \end{document}
+                     ] [31pdfTeX warning (ext4): destination with the same identifier (name{table.7.6}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.2321 \end{document}
+                     pdfTeX warning (ext4): destination with the same identifier (name{table.7.7}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.2321 \end{document}
+                     pdfTeX warning (ext4): destination with the same identifier (name{table.7.8}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.2321 \end{document}
+                     pdfTeX warning (ext4): destination with the same identifier (name{table.7.9}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.2321 \end{document}
+                     ] [32pdfTeX warning (ext4): destination with the same identifier (name{table.7.10}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.2321 \end{document}
+                     ] [33pdfTeX warning (ext4): destination with the same identifier (name{table.7.11}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.2321 \end{document}
+                     ] [34pdfTeX warning (ext4): destination with the same identifier (name{table.7.12}) has been already used, duplicate ignored
+<argument> ...shipout:D \box_use:N \l_shipout_box 
+                                                  \__shipout_drop_firstpage_...
+l.2321 \end{document}
+                     ] (./EES2019_synteval_mk.aux)
+
+LaTeX Warning: There were multiply-defined labels.
+
+Package rerunfilecheck Info: File `EES2019_synteval_mk.out' has not changed.
+(rerunfilecheck)             Checksum: ABB8BF1BCB2A754CC3DB47AF3DFB43EB;541.
+ ) 
+Here is how much of TeX's memory you used:
+ 12376 strings out of 480539
+ 181253 string characters out of 5901723
+ 579216 words of memory out of 5000000
+ 29632 multiletter control sequences out of 15000+600000
+ 465174 words of font info for 76 fonts, out of 8000000 for 9000
+ 14 hyphenation exceptions out of 8191
+ 60i,11n,66p,522b,361s stack positions out of 5000i,500n,10000p,200000b,80000s
+{/Users/matthias/Library/TinyTeX/texmf-dist/fonts/enc/dvips/lm/lm-mathit.enc}{/Users/matthias/Library/TinyTeX/texmf-dist/fonts/enc/dvips/lm/lm-mathsy.enc}{/Users/matthias/Library/TinyTeX/texmf-dist/fonts/enc/dvips/lm/lm-ec.enc}{/Users/matthias/Library/TinyTeX/texmf-dist/fonts/enc/dvips/lm/lm-ts1.enc}{/Users/matthias/Library/TinyTeX/texmf-dist/fonts/enc/dvips/lm/lm-rm.enc}</Users/matthias/Library/TinyTeX/texmf-dist/fonts/type1/public/lm/lmbx10.pfb></Users/matthias/Library/TinyTeX/texmf-dist/fonts/type1/public/lm/lmbx12.pfb></Users/matthias/Library/TinyTeX/texmf-dist/fonts/type1/public/lm/lmbx8.pfb></Users/matthias/Library/TinyTeX/texmf-dist/fonts/type1/public/lm/lmbx9.pfb></Users/matthias/Library/TinyTeX/texmf-dist/fonts/type1/public/lm/lmmi10.pfb></Users/matthias/Library/TinyTeX/texmf-dist/fonts/type1/public/lm/lmmi8.pfb></Users/matthias/Library/TinyTeX/texmf-dist/fonts/type1/public/lm/lmmi9.pfb></Users/matthias/Library/TinyTeX/texmf-dist/fonts/type1/public/lm/lmr10.pfb></Users/matthias/Library/TinyTeX/texmf-dist/fonts/type1/public/lm/lmr12.pfb></Users/matthias/Library/TinyTeX/texmf-dist/fonts/type1/public/lm/lmr17.pfb></Users/matthias/Library/TinyTeX/texmf-dist/fonts/type1/public/lm/lmr7.pfb></Users/matthias/Library/TinyTeX/texmf-dist/fonts/type1/public/lm/lmr8.pfb></Users/matthias/Library/TinyTeX/texmf-dist/fonts/type1/public/lm/lmr9.pfb></Users/matthias/Library/TinyTeX/texmf-dist/fonts/type1/public/lm/lmsy10.pfb></Users/matthias/Library/TinyTeX/texmf-dist/fonts/type1/public/lm/lmsy6.pfb></Users/matthias/Library/TinyTeX/texmf-dist/fonts/type1/public/lm/lmsy7.pfb></Users/matthias/Library/TinyTeX/texmf-dist/fonts/type1/public/lm/lmsy8.pfb></Users/matthias/Library/TinyTeX/texmf-dist/fonts/type1/public/lm/lmsy9.pfb>
+Output written on EES2019_synteval_mk.pdf (34 pages, 383299 bytes).
+PDF statistics:
+ 458 PDF objects out of 1000 (max. 8388607)
+ 380 compressed objects within 4 object streams
+ 121 named destinations out of 1000 (max. 500000)
+ 57 words of extra memory for PDF output out of 10000 (max. 10000000)
+

--- a/Scripts/country_spec_scripts/EES2019_at_genvars.R
+++ b/Scripts/country_spec_scripts/EES2019_at_genvars.R
@@ -97,7 +97,7 @@ EES2019_at_stack %<>%
 EES2019_at_stack %<>%
   left_join(.,
             lapply(data = EES2019_at_stack,
-                   cat.indvar =  c('D3_rec', 'D8_rec',  'D5_rec', 'EDU_rec'), # 'D6_rec', 'D9_rec'
+                   cat.indvar =  c('D3_rec', 'D8_rec',  'D5_rec', 'EDU_rec', 'D1_rec', 'D7_rec', 'D6_une'),
                    cont.indvar =  c('D4_age', 'D10_rec'),
                    yhat.name = 'socdem_synt',
                    regsum = F,

--- a/Scripts/country_spec_scripts/EES2019_fr_genvars.R
+++ b/Scripts/country_spec_scripts/EES2019_fr_genvars.R
@@ -96,7 +96,7 @@ EES2019_fr_stack %<>%
 EES2019_fr_stack %<>%
   left_join(.,
             lapply(data = EES2019_fr_stack,
-                   cat.indvar =  c('D3_rec', 'D8_rec',  'D5_rec', 'EDU_rec'), # 'D6_rec', 'D9_rec'
+                   cat.indvar =  c('D3_rec', 'D8_rec',  'D5_rec', 'EDU_rec', 'D1_rec', 'D7_rec', 'D6_une'),
                    cont.indvar =  c('D4_age', 'D10_rec'),
                    yhat.name = 'socdem_synt',
                    regsum = F,

--- a/Scripts/country_spec_scripts/EES2019_hr_genvars.R
+++ b/Scripts/country_spec_scripts/EES2019_hr_genvars.R
@@ -1,7 +1,7 @@
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Title: Script for Estimating Generic Variables (EES 2019 Voter Study, Croatian Sample) 
 # Author: M.Koernig
-# last update: 2021-10-21
+# last update: 2021-11-07
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 
@@ -106,7 +106,7 @@ EES2019_hr_stack %<>%
 EES2019_hr_stack %<>%
   left_join(.,
             lapply(data = EES2019_hr_stack,
-                   cat.indvar =  c('D3_rec', 'D8_rec',  'D5_rec', 'EDU_rec'), # 'D6_rec', 'D9_rec'
+                   cat.indvar =  c('D3_rec', 'D8_rec',  'D5_rec', 'EDU_rec', 'D1_rec', 'D7_rec', 'D6_une'),
                    cont.indvar =  c('D4_age', 'D10_rec'),
                    yhat.name = 'socdem_synt',
                    regsum = F,

--- a/Scripts/country_spec_scripts/EES2019_ie_genvars.R
+++ b/Scripts/country_spec_scripts/EES2019_ie_genvars.R
@@ -96,7 +96,7 @@ EES2019_ie_stack %<>%
 EES2019_ie_stack %<>%
   left_join(.,
             lapply(data = EES2019_ie_stack,
-                   cat.indvar =  c('D3_rec', 'D8_rec',  'D5_rec', 'EDU_rec'), # 'D6_rec', 'D9_rec'
+                   cat.indvar =  c('D3_rec', 'D8_rec',  'D5_rec', 'EDU_rec', 'D1_rec', 'D7_rec', 'D6_une'),
                    cont.indvar =  c('D4_age', 'D10_rec'),
                    yhat.name = 'socdem_synt',
                    regsum = F,
@@ -112,7 +112,7 @@ EES2019_ie_stack %<>%
 pred_1403_ie <- 
   gensyn.fun(data        = EES2019_ie_stack,
              depvar      = 'Q7_gen',
-             cat.indvar  = c('D3_rec', 'D8_rec', 'D5_rec', 'D1_rec', 'D7_rec'),
+             cat.indvar  = c('D3_rec', 'D8_rec', 'D5_rec', 'D1_rec', 'D7_rec', 'D6_une'),
              cont.indvar =  c('D4_age', 'D10_rec'),
              yhat.name   = 'socdem_synt',
              regsum      = F,

--- a/Scripts/country_spec_scripts/EES2019_lv_genvars.R
+++ b/Scripts/country_spec_scripts/EES2019_lv_genvars.R
@@ -95,7 +95,7 @@ EES2019_lv_stack %<>%
 EES2019_lv_stack %<>%
   left_join(.,
             lapply(data = EES2019_lv_stack,
-                   cat.indvar =  c('D3_rec', 'D8_rec',  'D5_rec', 'EDU_rec'), # 'D6_rec', 'D9_rec'
+                   cat.indvar =  c('D3_rec', 'D8_rec',  'D5_rec', 'EDU_rec', 'D1_rec', 'D7_rec', 'D6_une'), 
                    cont.indvar =  c('D4_age', 'D10_rec'),
                    yhat.name = 'socdem_synt',
                    regsum = F,
@@ -106,34 +106,44 @@ EES2019_lv_stack %<>%
   as_tibble()
 
 
-# prediction for party 1611, 1610, 1604, 1616 created w/ a different model
+# prediction for party 1611, 1610, 1604 created w/ a different model
 
-pred_1611_1610_1604_1616_lv <- 
+pred_1611_1610_1604_lv <- 
   gensyn.fun(data        = EES2019_lv_stack,
              depvar      = 'Q7_gen',
-             cat.indvar  = c('D3_rec', 'D8_rec', 'D5_rec', 'D1_rec', 'D7_rec'),
+             cat.indvar  = c('D3_rec', 'D8_rec', 'D5_rec', 'D1_rec', 'D7_rec', 'D6_une'),
              cont.indvar =  c('D4_age', 'D10_rec'),
              yhat.name   = 'socdem_synt',
              regsum      = F,
-             stack_party = c('1611', '1610', '1604', '1616')
+             stack_party = c('1611', '1610', '1604')
   )
 
 EES2019_lv_stack <-   
   left_join(EES2019_lv_stack %>% dplyr::select(-c(socdem_synt_vc)),
             EES2019_lv_stack %>% 
               dplyr::select(respid, party, socdem_synt_vc) %>% 
-              filter(party!=c(1611, 1610, 1604, 1616)) %>% 
-              rbind(pred_1611_1610_1604_1616_lv),
+              filter(party!=c(1611, 1610, 1604)) %>% 
+              rbind(pred_1611_1610_1604_lv),
             by = c('respid','party'))
+
+
+# prediction for party 1608 created w/ a different model
+
+# Found disruptive element in party 1605, with high std. errors in variable D6_une
+# However the didnt inc´fluence the constant
 
 
 # prediction for party 1605 created w/ a different model
 
-# Found disruptive elements in Model7, party 1605, with high std. errors in variables: EDU_rec, D5_rec
-# Excluding those two variables in a partial model got rid of the above probelem. However, a Chi-Squared 
-# test between the full/unconstrained one and partial/constrained one rejected the H0, that the constrained 
-# model fits better at p<0001.
-# Resulting in the choice to keep the full/unconstrained model7 with high std. errors
+# Found disruptive element in party 1605, with high std. errors in variable D5_rec
+# However the didnt inc´fluence the constant
+
+
+# prediction for party 1616 created w/ a different model
+
+# Party 1616 also shows inflated SE at the constant through EDU_rec and D6_rec. However, here we step 
+# back to implement a partial model because a constrained model without those variables was rejected at 
+# p<0.001 by a Chi-squared test in favor of the unconstrained model
 
 
 # Clean the environment # ==============================================================================

--- a/Scripts/country_spec_scripts/EES2019_pt_genvars.R
+++ b/Scripts/country_spec_scripts/EES2019_pt_genvars.R
@@ -96,7 +96,7 @@ EES2019_pt_stack %<>%
 EES2019_pt_stack %<>%
   left_join(.,
             lapply(data = EES2019_pt_stack,
-                   cat.indvar =  c('D3_rec', 'D8_rec',  'D5_rec', 'EDU_rec'), # 'D6_rec', 'D9_rec'
+                   cat.indvar =  c('D3_rec', 'D8_rec',  'D5_rec', 'EDU_rec', 'D1_rec', 'D7_rec', 'D6_une'), 
                    cont.indvar =  c('D4_age', 'D10_rec'),
                    yhat.name = 'socdem_synt',
                    regsum = F,

--- a/Scripts/country_spec_scripts/EES2019_ro_genvars.R
+++ b/Scripts/country_spec_scripts/EES2019_ro_genvars.R
@@ -103,7 +103,7 @@ EES2019_ro_stack %<>%
 EES2019_ro_stack %<>%
   left_join(.,
             lapply(data = EES2019_ro_stack,
-                   cat.indvar =  c('D3_rec', 'D8_rec',  'D5_rec', 'EDU_rec'), # 'D6_rec', 'D9_rec'
+                   cat.indvar =  c('D3_rec', 'D8_rec',  'D5_rec', 'EDU_rec', 'D1_rec', 'D7_rec', 'D6_une'), 
                    cont.indvar =  c('D4_age', 'D10_rec'),
                    yhat.name = 'socdem_synt',
                    regsum = F,
@@ -119,7 +119,7 @@ EES2019_ro_stack %<>%
 pred_2307_ro <- 
   gensyn.fun(data        = EES2019_ro_stack,
              depvar      = 'Q7_gen',
-             cat.indvar  = c('D3_rec', 'D8_rec', 'D5_rec', 'D1_rec', 'D7_rec'),
+             cat.indvar  = c('D3_rec', 'D8_rec', 'D5_rec', 'D1_rec', 'D7_rec', 'D6_une'),
              cont.indvar =  c('D4_age', 'D10_rec'),
              yhat.name   = 'socdem_synt',
              regsum      = F,

--- a/Scripts/country_spec_scripts/EES2019_si_genvars.R
+++ b/Scripts/country_spec_scripts/EES2019_si_genvars.R
@@ -96,7 +96,7 @@ EES2019_si_stack %<>%
 EES2019_si_stack %<>%
   left_join(.,
             lapply(data = EES2019_si_stack,
-                   cat.indvar =  c('D3_rec', 'D8_rec',  'D5_rec', 'EDU_rec'), # 'D6_rec', 'D9_rec'
+                   cat.indvar =  c('D3_rec', 'D8_rec',  'D5_rec', 'EDU_rec', 'D1_rec', 'D7_rec', 'D6_une'), 
                    cont.indvar =  c('D4_age', 'D10_rec'),
                    yhat.name = 'socdem_synt',
                    regsum = F,
@@ -112,7 +112,7 @@ EES2019_si_stack %<>%
 pred_2405_2408_si <- 
   gensyn.fun(data        = EES2019_si_stack,
              depvar      = 'Q7_gen',
-             cat.indvar  = c('D3_rec', 'D8_rec', 'D5_rec', 'D1_rec', 'D7_rec'),
+             cat.indvar  = c('D3_rec', 'D8_rec', 'D5_rec', 'D1_rec', 'D7_rec', 'D6_une'),
              cont.indvar =  c('D4_age', 'D10_rec'),
              yhat.name   = 'socdem_synt',
              regsum      = F,

--- a/Scripts/synteval_scripts/country_spec_scripts/EES2019_at_synteval.R
+++ b/Scripts/synteval_scripts/country_spec_scripts/EES2019_at_synteval.R
@@ -1,16 +1,16 @@
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Title: Script for Evaluating Synthetic Variables Estimation (EES 2019 Voter Study, Austrian Sample) 
 # Author: M.Körnig
-# last update: 2021-10-28
+# last update: 2021-11-05
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 # Country-spec workflow # ==============================================================================
 
 cntry = 'AT'
 
-EES2019_at <- EES2019 %>% filter(countryshort==cntry)
+EES2019_at       <- EES2019 %>% filter(countryshort==cntry)
 EES2019_stckd_at <- EES2019_stckd %>% filter(countryshort==cntry)
-EES2019_cdbk_at <- EES2019_cdbk %>% filter(countryshort==cntry)
+EES2019_cdbk_at  <- EES2019_cdbk %>% filter(countryshort==cntry)
 
 rm(cntry)
 
@@ -60,7 +60,7 @@ csdf_lst <- list('std'  = EES2019_at,
 syntvars_vrbls <- list('dep'   = list('OLS'     = 'Q10_gen', 
                                       'logit'   = 'Q7_gen'),
                        'indep' = list('ctgrcl' = c('D3_rec', 'D8_rec',  'D5_rec', 'EDU_rec', 
-                                                   'D1_rec', 'D7_rec'),
+                                                   'D1_rec', 'D7_rec', 'D6_une'),
                                       'cntns'  =  c('D4_age', 'D10_rec')))
 
 
@@ -120,7 +120,7 @@ nullmod_lst <- list('OLS'   = lapply(X = regdf_lst$OLS,   regmod = 'OLS',   null
 
 
 # fullmod_lst$OLS %>% lapply(.,summary)
-# fullmod_lst$logit %>% lapply(.,summary)  
+# fullmod_lst$logit %>% lapply(.,summary)
 
 # Syntvars evaluation: OLS models summary # ============================================================
 
@@ -142,12 +142,7 @@ nullmod_lst <- list('OLS'   = lapply(X = regdf_lst$OLS,   regmod = 'OLS',   null
 #                      header = F,
 #                      style = 'ajps')
 
-#large std. errors in Logit Model6: D8rec, D1rec
-
 # Syntvars evaluation: OLS models fit stats # ==========================================================
-
-# RMSE and Rsq # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-
 
 ols_df <- 
   tibble(
@@ -198,7 +193,7 @@ ols_df %<>%
 # Syntvars evaluation: logit models fit stats # ========================================================
 
 
-fulllogit_df <- 
+logit_df <- 
   tibble(
     'depvar'     = lapply(1:length(regdf_lst$logit), 
                           function(x){
@@ -218,68 +213,95 @@ fulllogit_df <-
                             fullmod_lst$logit[[x]] %>% AIC
                           }) %>% unlist
   ) %>% 
+  rbind(.,
+        tibble(
+          'depvar'     = lapply(1:length(regdf_lst$logit), 
+                                function(x){
+                                  names(regdf_lst$OLS[[x]]) %>% .[2]
+                                }) %>% unlist,
+          'model'      = rep('null',length(regdf_lst$logit)),
+          'Ps_Rsq'     = lapply(1:length(nullmod_lst$logit),
+                                function(x){
+                                  DescTools::PseudoR2(nullmod_lst$logit[[x]], which = 'McFadden')
+                                }) %>% unlist,
+          'Adj_Ps_Rsq' = lapply(1:length(nullmod_lst$logit),
+                                function(x){
+                                  DescTools::PseudoR2(nullmod_lst$logit[[x]], which = 'McFaddenAdj')
+                                }) %>% unlist,
+          'AIC'        = lapply(1:length(fullmod_lst$logit),
+                                function(x) {
+                                  nullmod_lst$logit[[x]] %>% AIC
+                                }) %>% unlist
+        ))
+
+
+logit_df %<>% 
   left_join(., relprty_df, by='depvar') %>% 
   dplyr::select(depvar, partycode, partyname_eng, model,
                 Ps_Rsq, Adj_Ps_Rsq, AIC)
 
 
+# AIC data frames # ====================================================================================
 
-nulllogit_df<- 
-  tibble(
-    'depvar'     = lapply(1:length(regdf_lst$logit), 
-                          function(x){
-                            names(regdf_lst$OLS[[x]]) %>% .[2]
-                          }) %>% unlist,
-    'model'      = rep('null',length(regdf_lst$logit)),
-    'Ps_Rsq'     = lapply(1:length(nullmod_lst$logit),
-                          function(x){
-                            DescTools::PseudoR2(nullmod_lst$logit[[x]], which = 'McFadden')
-                          }) %>% unlist,
-    'Adj_Ps_Rsq' = lapply(1:length(nullmod_lst$logit),
-                          function(x){
-                            DescTools::PseudoR2(nullmod_lst$logit[[x]], which = 'McFaddenAdj')
-                          }) %>% unlist,
-    'AIC'        = lapply(1:length(fullmod_lst$logit),
-                          function(x) {
-                            nullmod_lst$logit[[x]] %>% AIC
-                          }) %>% unlist
-  ) %>% 
-  left_join(., relprty_df, by='depvar') %>% 
-  dplyr::select(depvar, partycode, partyname_eng, model,
-                Ps_Rsq, Adj_Ps_Rsq, AIC)
+# OLS AIC df 
+
+ols_aic <- 
+  ols_df %>%
+  pivot_wider(id_cols = c('depvar', 'partycode', 'partyname_eng'), values_from = 'AIC',
+              names_from = 'model') %>%
+  mutate(diff = full - null) %>%
+  mutate(across(c('full', 'null', 'diff'), ~round(.,3))) %>%
+  dplyr::select(-c(partyname_eng))
+
+# Logit AIC df 
+
+logit_aic <- 
+  logit_df %>%
+  pivot_wider(id_cols = c('depvar', 'partycode', 'partyname_eng'), values_from = 'AIC',
+              names_from = 'model') %>%
+  mutate(diff = full - null) %>%
+  mutate(across(c('full', 'null', 'diff'), ~round(.,3))) %>%
+  dplyr::select(-c(partyname_eng))
+
+
+
+# Full models evaluation # =============================================================================
+
+# logit model 6 shows inflated SE on some predictors, more specifically: 
+# Model 6: D8_rec, D1_rec
+
+# Model 6  constant is affected showing unusual values. We deal only with model 6 affected 
+# by separation issue.
 
 
 # Syntvars evaluation: evaluating the source of misfit # ===============================================
 
+# Model 6 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 
-# One contingency table #D8rec
-df <- regdf_lst$logit[[6]]
-tabD8rec <- table(df$stack_105, df$D8_rec) %>% as.data.frame()
-names(tabD8rec)[1:2] <- c('stack_105', 'D8_rec')
-# Problem: no one voted for party 105 (Alliance for the Future of Austria) lives in a rural area
+mdl  <- 6
+df   <- regdf_lst$logit[[mdl]]
+cols <- c('D8_rec', 'D1_rec')
 
-# One contingency table #D1rec1
-df <- regdf_lst$logit[[6]]
-tabD1rec <- table(df$stack_105, df$D1_rec) %>% as.data.frame()
-names(tabD1rec)[1:2] <- c('stack_105', 'D1_rec')
-# Problem: no one voted for party 105 (Alliance for the Future of Austria) is member in a trade union membership
+tabs <- lapply(data=df, y='stack_105', na=T, X = cols, FUN = tab.auxfun)
+lapply(tabs, head)
+table(df$stack_105)
 
+# No respondents from rural areas, nor members of Trade unions did vote 
+# for party 105 (voted by only 10 respondents of the Austrian sample).
 
-# All the contingency tables # 
-
-tabs <- yxcontab.auxfun(regdf_lst$logit[[6]], contab = F)
-
-# look at elements of tabs list
-# lapply(tabs, head)
 
 
 # Syntvars evaluation: partial logit models # ==========================================================
 
 # Get the df for and estimate the partial models # - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
+vrbls_2_drop <- c('D8_rec', 'D1_rec')
+
 regdf_lst_part <- 
   regdf_lst$logit %>% 
-  lapply(., function(x){ x %<>% na.omit() %>% dplyr::select(-c(D8_rec, D1_rec))})
+  lapply(., function(x){
+    x %<>% na.omit() %>% dplyr::select(-c(all_of(vrbls_2_drop)))
+  }) 
 
 partmod_lst <- 
   lapply(regdf_lst_part, function(x){
@@ -294,15 +316,17 @@ partmod_lst <-
 
 # LR test (Chisq) # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 
+mdls <- c(6)
+
 anova_lst <- 
-  anova.auxfun(mdl_lst1 = partmod_lst,
-               mdl_lst2 = fullmod_lst$logit,
+  anova.auxfun(mdl_lst1 = partmod_lst[c(mdls)],
+               mdl_lst2 = fullmod_lst$logit[c(mdls)],
                table = F)
+
 
 # lapply(anova_lst, head)
 
-#For Model 1,3,4,5 H0 can not be rejected
-#For Model 2,6 H0 cn be rejected at p<0
+#For Model 6 H0 can be rejected at p<0.001
 
 # stargazer::stargazer(partmod_lst, type = 'text',
 #                      column.labels = as.character(relprty_df$Q7),
@@ -312,45 +336,13 @@ anova_lst <-
 #                      header = F,
 #                      style = 'ajps')
 
-# Partial models fit summary # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
+# Syntvars evaluation: Updating logit models (and related data frames) lists # ===============================
 
-partlogit_df <-  
-  tibble(
-    'depvar'     = lapply(1:length(partmod_lst), 
-                          function(x){
-                            names(regdf_lst_part[[x]]) %>% .[2]
-                          }) %>% unlist,
-    'model'      = rep('partial',length(regdf_lst_part)),
-    'Ps_Rsq'     = lapply(1:length(partmod_lst),
-                          function(x){
-                            DescTools::PseudoR2(partmod_lst[[x]], which = 'McFadden')
-                          }) %>% unlist,
-    'Adj_Ps_Rsq' = lapply(1:length(partmod_lst),
-                          function(x){
-                            DescTools::PseudoR2(partmod_lst[[x]], which = 'McFaddenAdj')
-                          }) %>% unlist,
-    'AIC'        = lapply(1:length(partmod_lst),
-                          function(x) {
-                            partmod_lst[[x]] %>% AIC
-                          }) %>% unlist
-  ) %>% 
-  left_join(., relprty_df, by='depvar') %>% 
-  dplyr::select(depvar, partycode, partyname_eng, model,
-                Ps_Rsq, Adj_Ps_Rsq, AIC)
+# fullmod_lst$logit[c(mdls)] <- partmod_lst[c(mdls)]
 
-
-# Syntvars evaluation: New logit models fit stats # ====================================================
-
-logit_df <-  
-  fulllogit_df %>% 
-  rbind(., partlogit_df) %>% 
-  rbind(., nulllogit_df)
-
-
-
-# Clean the environment # ==============================================================================
-
-rm(list=ls(pattern='auxfun|regdf|partlogit|fulllogit|nulllogit'))
+finalmod_lst <- list()
+finalmod_lst[['OLS']] <- fullmod_lst[['OLS']]
+finalmod_lst[['logit']] <- fullmod_lst[['logit']]
 
 

--- a/Scripts/synteval_scripts/country_spec_scripts/EES2019_fr_synteval.R
+++ b/Scripts/synteval_scripts/country_spec_scripts/EES2019_fr_synteval.R
@@ -1,7 +1,7 @@
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Title: Script for Evaluating Synthetic Variables Estimation (EES 2019 Voter Study, French Sample) 
 # Author: M.Körnig
-# last update: 2021-10-28
+# last update: 2021-11-06
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 # Country-spec workflow # ==============================================================================
@@ -60,7 +60,7 @@ csdf_lst <- list('std'  = EES2019_fr,
 syntvars_vrbls <- list('dep'   = list('OLS'     = 'Q10_gen', 
                                       'logit'   = 'Q7_gen'),
                        'indep' = list('ctgrcl' = c('D3_rec', 'D8_rec',  'D5_rec', 'EDU_rec', 
-                                                   'D1_rec', 'D7_rec'),
+                                                   'D1_rec', 'D7_rec', 'D6_une'),
                                       'cntns'  =  c('D4_age', 'D10_rec')))
 
 
@@ -197,8 +197,7 @@ ols_df %<>%
 
 # Syntvars evaluation: logit models fit stats # ========================================================
 
-
-fulllogit_df <- 
+logit_df <- 
   tibble(
     'depvar'     = lapply(1:length(regdf_lst$logit), 
                           function(x){
@@ -218,42 +217,79 @@ fulllogit_df <-
                             fullmod_lst$logit[[x]] %>% AIC
                           }) %>% unlist
   ) %>% 
+  rbind(.,
+        tibble(
+          'depvar'     = lapply(1:length(regdf_lst$logit), 
+                                function(x){
+                                  names(regdf_lst$OLS[[x]]) %>% .[2]
+                                }) %>% unlist,
+          'model'      = rep('null',length(regdf_lst$logit)),
+          'Ps_Rsq'     = lapply(1:length(nullmod_lst$logit),
+                                function(x){
+                                  DescTools::PseudoR2(nullmod_lst$logit[[x]], which = 'McFadden')
+                                }) %>% unlist,
+          'Adj_Ps_Rsq' = lapply(1:length(nullmod_lst$logit),
+                                function(x){
+                                  DescTools::PseudoR2(nullmod_lst$logit[[x]], which = 'McFaddenAdj')
+                                }) %>% unlist,
+          'AIC'        = lapply(1:length(fullmod_lst$logit),
+                                function(x) {
+                                  nullmod_lst$logit[[x]] %>% AIC
+                                }) %>% unlist
+        ))
+
+
+logit_df %<>% 
   left_join(., relprty_df, by='depvar') %>% 
   dplyr::select(depvar, partycode, partyname_eng, model,
                 Ps_Rsq, Adj_Ps_Rsq, AIC)
 
 
+# AIC data frames # ====================================================================================
 
-nulllogit_df<- 
-  tibble(
-    'depvar'     = lapply(1:length(regdf_lst$logit), 
-                          function(x){
-                            names(regdf_lst$OLS[[x]]) %>% .[2]
-                          }) %>% unlist,
-    'model'      = rep('null',length(regdf_lst$logit)),
-    'Ps_Rsq'     = lapply(1:length(nullmod_lst$logit),
-                          function(x){
-                            DescTools::PseudoR2(nullmod_lst$logit[[x]], which = 'McFadden')
-                          }) %>% unlist,
-    'Adj_Ps_Rsq' = lapply(1:length(nullmod_lst$logit),
-                          function(x){
-                            DescTools::PseudoR2(nullmod_lst$logit[[x]], which = 'McFaddenAdj')
-                          }) %>% unlist,
-    'AIC'        = lapply(1:length(fullmod_lst$logit),
-                          function(x) {
-                            nullmod_lst$logit[[x]] %>% AIC
-                          }) %>% unlist
-  ) %>% 
-  left_join(., relprty_df, by='depvar') %>% 
-  dplyr::select(depvar, partycode, partyname_eng, model,
-                Ps_Rsq, Adj_Ps_Rsq, AIC)
+# OLS AIC df 
+
+ols_aic <- 
+  ols_df %>%
+  pivot_wider(id_cols = c('depvar', 'partycode', 'partyname_eng'), values_from = 'AIC',
+              names_from = 'model') %>%
+  mutate(diff = full - null) %>%
+  mutate(across(c('full', 'null', 'diff'), ~round(.,3))) %>%
+  dplyr::select(-c(partyname_eng))
+
+# Logit AIC df 
+
+logit_aic <- 
+  logit_df %>%
+  pivot_wider(id_cols = c('depvar', 'partycode', 'partyname_eng'), values_from = 'AIC',
+              names_from = 'model') %>%
+  mutate(diff = full - null) %>%
+  mutate(across(c('full', 'null', 'diff'), ~round(.,3))) %>%
+  dplyr::select(-c(partyname_eng))
 
 
-# Syntvars evaluation: New logit models fit stats # ====================================================
 
-logit_df <-  
-  fulllogit_df %>% 
-  rbind(., nulllogit_df)
+# Full models evaluation # =============================================================================
+
+#no problems and inflated SE occur in logit or OLS regression, thus no partial model modification necessary
+
+
+# Syntvars evaluation: Updating logit models (and related data frames) lists # ===============================
+
+# fullmod_lst$logit[c(mdls)] <- partmod_lst[c(mdls)]
+
+finalmod_lst <- list()
+finalmod_lst[['OLS']] <- fullmod_lst[['OLS']]
+finalmod_lst[['logit']] <- fullmod_lst[['logit']]
+
+
+# stargazer::stargazer(finalmod_lst$logit, type = 'text',
+#                      column.labels = as.character(relprty_df$Q7),
+#                      dep.var.labels = 'Vote choice',
+#                      star.cutoffs = c(0.05, 0.01, 0.001),
+#                      omit.stat=c("f", "ser"),
+#                      header = F,
+#                      style = 'ajps')
 
 
 

--- a/Scripts/synteval_scripts/country_spec_scripts/EES2019_hr_synteval.R
+++ b/Scripts/synteval_scripts/country_spec_scripts/EES2019_hr_synteval.R
@@ -1,7 +1,7 @@
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Title: Script for Evaluating Synthetic Variables Estimation (EES 2019 Voter Study, Croatian Sample) 
 # Author: M.Körnig
-# last update: 2021-10-28
+# last update: 2021-11-06
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 # Country-spec workflow # ==============================================================================
@@ -60,7 +60,7 @@ csdf_lst <- list('std'  = EES2019_hr,
 syntvars_vrbls <- list('dep'   = list('OLS'     = 'Q10_gen', 
                                       'logit'   = 'Q7_gen'),
                        'indep' = list('ctgrcl' = c('D3_rec', 'D8_rec',  'D5_rec', 'EDU_rec', 
-                                                   'D1_rec', 'D7_rec'),
+                                                   'D1_rec', 'D7_rec', 'D6_une'),
                                       'cntns'  =  c('D4_age', 'D10_rec')))
 
 
@@ -134,18 +134,13 @@ nullmod_lst <- list('OLS'   = lapply(X = regdf_lst$OLS,   regmod = 'OLS',   null
 
 # Syntvars evaluation: logit models summary # ==========================================================
 
-stargazer::stargazer(fullmod_lst$logit, type = 'text',
-                     column.labels = as.character(relprty_df$Q7),
-                     dep.var.labels = 'Vote choice',
-                     star.cutoffs = c(0.05, 0.01, 0.001),
-                     omit.stat=c("f", "ser"),
-                     header = F,
-                     style = 'ajps')
-
-#high std. errors in logit model4 Edu_rec, constant
-#high std. errors in logit model5 constant only
-#high std. errors in logit model6 Edu_rec, constant
-#high std. errors in logit model7 Edu_rec, D8_rec, D5_rec, D7_rec
+# stargazer::stargazer(fullmod_lst$logit, type = 'text',
+#                      column.labels = as.character(relprty_df$Q7),
+#                      dep.var.labels = 'Vote choice',
+#                      star.cutoffs = c(0.05, 0.01, 0.001),
+#                      omit.stat=c("f", "ser"),
+#                      header = F,
+#                      style = 'ajps')
 
 
 # Syntvars evaluation: OLS models fit stats # ==========================================================
@@ -202,7 +197,10 @@ ols_df %<>%
 # Syntvars evaluation: logit models fit stats # ========================================================
 
 
-fulllogit_df <- 
+# Syntvars evaluation: logit models fit stats # ========================================================
+
+
+logit_df <- 
   tibble(
     'depvar'     = lapply(1:length(regdf_lst$logit), 
                           function(x){
@@ -222,72 +220,111 @@ fulllogit_df <-
                             fullmod_lst$logit[[x]] %>% AIC
                           }) %>% unlist
   ) %>% 
+  rbind(.,
+        tibble(
+          'depvar'     = lapply(1:length(regdf_lst$logit), 
+                                function(x){
+                                  names(regdf_lst$OLS[[x]]) %>% .[2]
+                                }) %>% unlist,
+          'model'      = rep('null',length(regdf_lst$logit)),
+          'Ps_Rsq'     = lapply(1:length(nullmod_lst$logit),
+                                function(x){
+                                  DescTools::PseudoR2(nullmod_lst$logit[[x]], which = 'McFadden')
+                                }) %>% unlist,
+          'Adj_Ps_Rsq' = lapply(1:length(nullmod_lst$logit),
+                                function(x){
+                                  DescTools::PseudoR2(nullmod_lst$logit[[x]], which = 'McFaddenAdj')
+                                }) %>% unlist,
+          'AIC'        = lapply(1:length(fullmod_lst$logit),
+                                function(x) {
+                                  nullmod_lst$logit[[x]] %>% AIC
+                                }) %>% unlist
+        ))
+
+
+logit_df %<>% 
   left_join(., relprty_df, by='depvar') %>% 
   dplyr::select(depvar, partycode, partyname_eng, model,
                 Ps_Rsq, Adj_Ps_Rsq, AIC)
 
 
+# AIC data frames # ====================================================================================
 
-nulllogit_df<- 
-  tibble(
-    'depvar'     = lapply(1:length(regdf_lst$logit), 
-                          function(x){
-                            names(regdf_lst$OLS[[x]]) %>% .[2]
-                          }) %>% unlist,
-    'model'      = rep('null',length(regdf_lst$logit)),
-    'Ps_Rsq'     = lapply(1:length(nullmod_lst$logit),
-                          function(x){
-                            DescTools::PseudoR2(nullmod_lst$logit[[x]], which = 'McFadden')
-                          }) %>% unlist,
-    'Adj_Ps_Rsq' = lapply(1:length(nullmod_lst$logit),
-                          function(x){
-                            DescTools::PseudoR2(nullmod_lst$logit[[x]], which = 'McFaddenAdj')
-                          }) %>% unlist,
-    'AIC'        = lapply(1:length(fullmod_lst$logit),
-                          function(x) {
-                            nullmod_lst$logit[[x]] %>% AIC
-                          }) %>% unlist
-  ) %>% 
-  left_join(., relprty_df, by='depvar') %>% 
-  dplyr::select(depvar, partycode, partyname_eng, model,
-                Ps_Rsq, Adj_Ps_Rsq, AIC)
+# OLS AIC df 
+
+ols_aic <- 
+  ols_df %>%
+  pivot_wider(id_cols = c('depvar', 'partycode', 'partyname_eng'), values_from = 'AIC',
+              names_from = 'model') %>%
+  mutate(diff = full - null) %>%
+  mutate(across(c('full', 'null', 'diff'), ~round(.,3))) %>%
+  dplyr::select(-c(partyname_eng))
+
+# Logit AIC df 
+
+logit_aic <- 
+  logit_df %>%
+  pivot_wider(id_cols = c('depvar', 'partycode', 'partyname_eng'), values_from = 'AIC',
+              names_from = 'model') %>%
+  mutate(diff = full - null) %>%
+  mutate(across(c('full', 'null', 'diff'), ~round(.,3))) %>%
+  dplyr::select(-c(partyname_eng))
+
+
+
+# Full models evaluation # =============================================================================
+
+# logit models 6,7 show inflated SE on some predictors, more specifically: 
+# Model 6: Edu_rec, D6_une
+# Model 7: Edu_rec, D8_rec, D5_rec, D7_rec (only category 2), D6_une
+
+# Models 6,7 constant is affected showing unusual values. We deal with models 6,7 affected 
+# by separation issue.
+
 
 
 # Syntvars evaluation: evaluating the source of misfit # ===============================================
 
+# Model 6 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 
-# One contingency table #Edu_rec
-df <- regdf_lst$logit[[4]]
-tab4EDU_rec <- table(df$stack_405, df$EDU_rec) %>% as.data.frame()
-names(tab4EDU_rec)[1:2] <- c('stack_405', 'EDU_rec')
-# Problem: no one voted for party 105 (Alliance for the Future of Austria) lives in a rural area
+mdl  <- 6
+df   <- regdf_lst$logit[[mdl]]
+cols <- c('EDU_rec', 'D6_une')
 
-# One contingency table #EDU_rec
-df <- regdf_lst$logit[[6]]
-tab6EDU_rec <- table(df$stack_413, df$EDU_rec) %>% as.data.frame()
-names(tab6EDU_rec)[1:2] <- c('stack_413', 'EDU_rec')
+tabs <- lapply(data=df, y='stack_413', na=T, X = cols, FUN = tab.auxfun)
+lapply(tabs, head)
+table(df$stack_413)
 
+# No respondents with 15 years or less education and unemployement did vote 
+# for party 413 (voted by only 16 respondents of the Croatian sample).
 
+mdl  <- 7
+df   <- regdf_lst$logit[[mdl]]
+cols <- c('EDU_rec', 'D6_une', 'D7_rec', 'D5_rec', 'D8_rec')
 
-# All the contingency tables #only constant for model5 
-tabs5 <- yxcontab.auxfun(regdf_lst$logit[[5]], contab = F)
-# look at elements of tabs list
-# lapply(tabs5, head)
+tabs2 <- lapply(data=df, y='stack_401', na=T, X = cols, FUN = tab.auxfun)
+lapply(tabs2, head)
+table(df$stack_401)
 
-# All the contingency tables #model7 - D8_rec, D5_rec, EDU_rec, D7_rec
-tabs7 <- yxcontab.auxfun(regdf_lst$logit[[7]], contab = F)
-# look at elements of tabs list
-# lapply(tabs7, head)
+# No respondents with 15 years or less education, unemployement, without a lifepartner or of a rural area 
+# and only one respondent in the upper class did vote
+# for party 401 (voted by only 7 respondents of the Croatian sample).
 
 
 # Syntvars evaluation: partial logit models # ==========================================================
 
-# Case 1: Only exclusing EDU_rec as variable # - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Get the df for and estimate the partial models # - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+vrbls_2_drop <- c('EDU_rec', 'D6_une') #for model6
+vrbls_2_drop2 <- c('EDU_rec', 'D6_une', 'D7_rec', 'D5_rec', 'D8_rec') #for model7
 
 regdf_lst_part <- 
   regdf_lst$logit %>% 
-  lapply(., function(x){ x %<>% na.omit() %>% dplyr::select(-EDU_rec)})
+  lapply(., function(x){
+    x %<>% na.omit() %>% dplyr::select(-c(all_of(vrbls_2_drop)))
+  }) 
+
+regdf_lst_part[[7]] <- regdf_lst_part[[7]][,!(names(regdf_lst_part[[7]]) %in% vrbls_2_drop2)]
 
 partmod_lst <- 
   lapply(regdf_lst_part, function(x){
@@ -302,133 +339,70 @@ partmod_lst <-
 
 # LR test (Chisq) # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 
+mdls <- c(6,7)
+
 anova_lst <- 
-  anova.auxfun(mdl_lst1 = partmod_lst,
-               mdl_lst2 = fullmod_lst$logit,
-               table = F)
+  anova.auxfun(mdl_lst1 = partmod_lst[c(mdls)],
+               mdl_lst2 = fullmod_lst$logit[c(mdls)],
+               table = T)
+
 
 # lapply(anova_lst, head)
-#For Model 1,2,3,4,5,6,7 H0 can not be rejected
+
+# For Model 6 H0 can not be rejected
+# For Model 7 H0 can be rejected at p<0.1
 
 # stargazer::stargazer(partmod_lst, type = 'text',
-#                                             column.labels = as.character(relprty_df$Q7),
-#                                             dep.var.labels = 'Vote choice',
-#                                             star.cutoffs = c(0.05, 0.01, 0.001),
-#                                             omit.stat=c("f", "ser"),
-#                                             header = F,
-#                                             style = 'ajps')
-
-#problem of high std. errors solved for model6, but not for model7, however it decreased around halve
+#                      column.labels = as.character(relprty_df$Q7),
+#                      dep.var.labels = 'Vote choice',
+#                      star.cutoffs = c(0.05, 0.01, 0.001),
+#                      omit.stat=c("f", "ser"),
+#                      header = F,
+#                      style = 'ajps')
 
 
-# Partial models fit summary for  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Syntvars evaluation: Updating logit models (and related data frames) lists # ===============================
+
+# fullmod_lst$logit[c(mdls)] <- partmod_lst[c(mdls)]
+
+finalmod_lst <- list()
+finalmod_lst[['OLS']] <- fullmod_lst[['OLS']]
+finalmod_lst[['logit']] <- fullmod_lst[['logit']]
+
+finalmod_lst[['logit']][[8]] <- finalmod_lst[['logit']][[7]]
+finalmod_lst[['logit']][[7]] <- partmod_lst[[6]]
+finalmod_lst[['logit']][[9]] <- partmod_lst[[7]]
 
 
-partlogit_df <-  
-  tibble(
-    'depvar'     = lapply(1:length(partmod_lst), 
-                          function(x){
-                            names(regdf_lst_part[[x]]) %>% .[2]
-                          }) %>% unlist,
-    'model'      = rep('partial',length(regdf_lst_part)),
-    'Ps_Rsq'     = lapply(1:length(partmod_lst),
-                          function(x){
-                            DescTools::PseudoR2(partmod_lst[[x]], which = 'McFadden')
-                          }) %>% unlist,
-    'Adj_Ps_Rsq' = lapply(1:length(partmod_lst),
-                          function(x){
-                            DescTools::PseudoR2(partmod_lst[[x]], which = 'McFaddenAdj')
-                          }) %>% unlist,
-    'AIC'        = lapply(1:length(partmod_lst),
-                          function(x) {
-                            partmod_lst[[x]] %>% AIC
-                          }) %>% unlist
-  ) %>% 
-  left_join(., relprty_df, by='depvar') %>% 
-  dplyr::select(depvar, partycode, partyname_eng, model,
-                Ps_Rsq, Adj_Ps_Rsq, AIC)
+# stargazer::stargazer(finalmod_lst$logit, type = 'text',
+#                      column.labels = as.character(relprty_df$Q7),
+#                      dep.var.labels = 'Vote choice',
+#                      star.cutoffs = c(0.05, 0.01, 0.001),
+#                      omit.stat=c("f", "ser"),
+#                      header = F,
+#                      style = 'ajps')
 
 
-# Case 2 excluding also other variables than EDU_rec # - - - - - - - - - - - - - - - - - - - - - - - - -
-# Get the df for and estimate the partial models # - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Syntvars evaluation: Updating AIC data frames (logit only) # =========================================
 
-regdf_lst_part2 <- 
-  regdf_lst$logit %>% 
-  lapply(., function(x){ x %<>% na.omit() %>% dplyr::select(-c(EDU_rec, D8_rec, D5_rec, D7_rec))})
+# logit AIC df 
 
-partmod_lst2 <- 
-  lapply(regdf_lst_part2, function(x){
-    y    <- names(x)[startsWith(names(x), 'stack')]
-    xs   <- names(x)[3:length(x)]
-    frml <- paste(y, paste0(xs, collapse = ' + '), sep = " ~ ") %>% as.formula
-    
-    fit <- glm(data = x, formula = frml, family = binomial)
-    
-    return(fit)
-  })
+logit_aic %<>% 
+  rbind(.,
+        tibble('depvar'    = 'stack_413',
+               'partycode' = 413, 
+               'full'      = partmod_lst[[6]] %>% AIC,
+               'null'      = nullmod_lst$logit[[6]] %>% AIC,
+        ) %>% 
+          mutate(diff = full-null)) %>% 
+  rbind(.,
+        tibble('depvar'    = 'stack_401',
+               'partycode' = 401, 
+               'full'      = partmod_lst[[7]] %>% AIC,
+               'null'      = nullmod_lst$logit[[7]] %>% AIC,
+        ) %>% 
+          mutate(diff = full-null)) %>%
+  .[order(.$depvar, .$partycode),] 
 
-# LR test (Chisq) # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-
-anova_lst2 <- 
-  anova.auxfun(mdl_lst1 = partmod_lst2,
-               mdl_lst2 = fullmod_lst$logit,
-               table = F)
-
-# lapply(anova_lst2, head)
-#For Model 1,2,3,4,5,6 H0 can not be rejected
-#For Model 7 can only be rejected at p<0.1
-
-stargazer::stargazer(partmod_lst2, type = 'text',
-                                            column.labels = as.character(relprty_df$Q7),
-                                            dep.var.labels = 'Vote choice',
-                                            star.cutoffs = c(0.05, 0.01, 0.001),
-                                            omit.stat=c("f", "ser"),
-                                            header = F,
-                                            style = 'ajps')
-
-#problem of high std. errors solved for all models
-
-
-# Partial models fit summary for  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-
-
-partlogit_df2 <-  
-  tibble(
-    'depvar'     = lapply(1:length(partmod_lst2), 
-                          function(x){
-                            names(regdf_lst_part2[[x]]) %>% .[2]
-                          }) %>% unlist,
-    'model'      = rep('partial2',length(regdf_lst_part2)),
-    'Ps_Rsq'     = lapply(1:length(partmod_lst2),
-                          function(x){
-                            DescTools::PseudoR2(partmod_lst2[[x]], which = 'McFadden')
-                          }) %>% unlist,
-    'Adj_Ps_Rsq' = lapply(1:length(partmod_lst2),
-                          function(x){
-                            DescTools::PseudoR2(partmod_lst2[[x]], which = 'McFaddenAdj')
-                          }) %>% unlist,
-    'AIC'        = lapply(1:length(partmod_lst2),
-                          function(x) {
-                            partmod_lst2[[x]] %>% AIC
-                          }) %>% unlist
-  ) %>% 
-  left_join(., relprty_df, by='depvar') %>% 
-  dplyr::select(depvar, partycode, partyname_eng, model,
-                Ps_Rsq, Adj_Ps_Rsq, AIC)
-
-
-# Syntvars evaluation: New logit models fit stats # ====================================================
-
-logit_df <-  
-  fulllogit_df %>% 
-  rbind(., partlogit_df) %>% 
-  rbind(., partlogit_df2) %>%
-  rbind(., nulllogit_df)
-
-
-
-# Clean the environment # ==============================================================================
-
-rm(list=ls(pattern='auxfun|regdf|partlogit|fulllogit|nulllogit'))
 
 

--- a/Scripts/synteval_scripts/country_spec_scripts/EES2019_lv_synteval.R
+++ b/Scripts/synteval_scripts/country_spec_scripts/EES2019_lv_synteval.R
@@ -1,7 +1,7 @@
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-# Title: Script for Evaluating Synthetic Variables Estimation (EES 2019 Voter Study, Irish Sample) 
+# Title: Script for Evaluating Synthetic Variables Estimation (EES 2019 Voter Study, Latvian Sample) 
 # Author: M.Körnig
-# last update: 2021-10-21
+# last update: 2021-11-06
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 # Country-spec workflow # ==============================================================================
@@ -60,7 +60,7 @@ csdf_lst <- list('std'  = EES2019_lv,
 syntvars_vrbls <- list('dep'   = list('OLS'     = 'Q10_gen', 
                                       'logit'   = 'Q7_gen'),
                        'indep' = list('ctgrcl' = c('D3_rec', 'D8_rec',  'D5_rec', 'EDU_rec', 
-                                                   'D1_rec', 'D7_rec'),
+                                                   'D1_rec', 'D7_rec', 'D6_une'),
                                       'cntns'  =  c('D4_age', 'D10_rec')))
 
 
@@ -142,8 +142,10 @@ nullmod_lst <- list('OLS'   = lapply(X = regdf_lst$OLS,   regmod = 'OLS',   null
 #                      header = F,
 #                      style = 'ajps')
 
-#large std. errors in Logit Model1,5,6,7: EDU_rec, constant
-#large std. errors in Logit Model4: EDU_rec, D5_rec, constant
+#large SE in M1,7: EDU_rec, D6_une, constant
+#large SE in M5,6: EDU_rec, constant
+#large SE in M2: D6_une without constant
+#large SE in M4: D5_rec, constant
 
 # Syntvars evaluation: OLS models fit stats # ==========================================================
 
@@ -198,8 +200,7 @@ ols_df %<>%
 
 # Syntvars evaluation: logit models fit stats # ========================================================
 
-
-fulllogit_df <- 
+logit_df <- 
   tibble(
     'depvar'     = lapply(1:length(regdf_lst$logit), 
                           function(x){
@@ -219,67 +220,168 @@ fulllogit_df <-
                             fullmod_lst$logit[[x]] %>% AIC
                           }) %>% unlist
   ) %>% 
+  rbind(.,
+        tibble(
+          'depvar'     = lapply(1:length(regdf_lst$logit), 
+                                function(x){
+                                  names(regdf_lst$OLS[[x]]) %>% .[2]
+                                }) %>% unlist,
+          'model'      = rep('null',length(regdf_lst$logit)),
+          'Ps_Rsq'     = lapply(1:length(nullmod_lst$logit),
+                                function(x){
+                                  DescTools::PseudoR2(nullmod_lst$logit[[x]], which = 'McFadden')
+                                }) %>% unlist,
+          'Adj_Ps_Rsq' = lapply(1:length(nullmod_lst$logit),
+                                function(x){
+                                  DescTools::PseudoR2(nullmod_lst$logit[[x]], which = 'McFaddenAdj')
+                                }) %>% unlist,
+          'AIC'        = lapply(1:length(fullmod_lst$logit),
+                                function(x) {
+                                  nullmod_lst$logit[[x]] %>% AIC
+                                }) %>% unlist
+        ))
+
+
+logit_df %<>% 
   left_join(., relprty_df, by='depvar') %>% 
   dplyr::select(depvar, partycode, partyname_eng, model,
                 Ps_Rsq, Adj_Ps_Rsq, AIC)
 
 
+# AIC data frames # ====================================================================================
 
-nulllogit_df<- 
-  tibble(
-    'depvar'     = lapply(1:length(regdf_lst$logit), 
-                          function(x){
-                            names(regdf_lst$OLS[[x]]) %>% .[2]
-                          }) %>% unlist,
-    'model'      = rep('null',length(regdf_lst$logit)),
-    'Ps_Rsq'     = lapply(1:length(nullmod_lst$logit),
-                          function(x){
-                            DescTools::PseudoR2(nullmod_lst$logit[[x]], which = 'McFadden')
-                          }) %>% unlist,
-    'Adj_Ps_Rsq' = lapply(1:length(nullmod_lst$logit),
-                          function(x){
-                            DescTools::PseudoR2(nullmod_lst$logit[[x]], which = 'McFaddenAdj')
-                          }) %>% unlist,
-    'AIC'        = lapply(1:length(fullmod_lst$logit),
-                          function(x) {
-                            nullmod_lst$logit[[x]] %>% AIC
-                          }) %>% unlist
-  ) %>% 
-  left_join(., relprty_df, by='depvar') %>% 
-  dplyr::select(depvar, partycode, partyname_eng, model,
-                Ps_Rsq, Adj_Ps_Rsq, AIC)
+# OLS AIC df 
+
+ols_aic <- 
+  ols_df %>%
+  pivot_wider(id_cols = c('depvar', 'partycode', 'partyname_eng'), values_from = 'AIC',
+              names_from = 'model') %>%
+  mutate(diff = full - null) %>%
+  mutate(across(c('full', 'null', 'diff'), ~round(.,3))) %>%
+  dplyr::select(-c(partyname_eng))
+
+# Logit AIC df 
+
+logit_aic <- 
+  logit_df %>%
+  pivot_wider(id_cols = c('depvar', 'partycode', 'partyname_eng'), values_from = 'AIC',
+              names_from = 'model') %>%
+  mutate(diff = full - null) %>%
+  mutate(across(c('full', 'null', 'diff'), ~round(.,3))) %>%
+  dplyr::select(-c(partyname_eng))
+
+
+
+# Full models evaluation # =============================================================================
+
+# logit models 1,2,4,5,6,7 show inflated SE on some predictors, more specifically: 
+# Model 1,7: EDU_rec, D6_une
+# Model 5,6: EDU_rec
+# Model 2: D6_une
+# Model 4: D5_rec
+
+# Models 1,4,5,6,7 constant is affected showing unusual values, but not Model 2. 
+# We deal with models 6,7 affected by separation issue.
 
 
 # Syntvars evaluation: evaluating the source of misfit # ===============================================
 
+# Model 1 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+mdl  <- 1
+df   <- regdf_lst$logit[[mdl]]
+cols <- c('EDU_rec', 'D6_une')
 
-# One contingency table #Edu_rec
-df <- regdf_lst$logit[[1]]
-tab1EDU_rec <- table(df$stack_1611, df$EDU_rec) %>% as.data.frame()
-names(tab1EDU_rec)[1:2] <- c('stack_1611', 'EDU_rec')
-# Problem: only one voted for party 1611 (For Fatherland and Freedom) and has 15 years or less education
-#same is true for model 4,5,6,7
-
-# One contingency table #D5_rec
-df <- regdf_lst$logit[[4]]
-tab4D5_rec <- table(df$stack_1605, df$D5_rec) %>% as.data.frame()
-names(tab4D5_rec)[1:2] <- c('stack_1605', 'D5_rec')
-
-
-# All the contingency tables #only constant for model5 
-tabs <- yxcontab.auxfun(regdf_lst$logit[[4]], contab = F)
-# look at elements of tabs list
+tabs <- lapply(data=df, y='stack_1611', na=T, X = cols, FUN = tab.auxfun)
 # lapply(tabs, head)
+# table(df$stack_1611)
+
+# One respondent with 15 years or less education and one unemployed did vote 
+# for party 1611 (voted by 86 respondents of the Latvian sample).
+
+# Model 2 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+mdl  <- 2
+df   <- regdf_lst$logit[[mdl]]
+cols <- 'D6_une'
+
+tabs2 <- lapply(data=df, y='stack_1608', na=T, X = cols, FUN = tab.auxfun)
+# lapply(tabs2, head)
+# table(df$stack_1608)
+
+# No respondent in unemployement did vote
+# for party 1608 (voted by only 44 respondents of the Latvian sample).
+
+# Model 4 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+mdl  <- 4
+df   <- regdf_lst$logit[[mdl]]
+cols <- 'D5_rec'
+
+tabs3 <- lapply(data=df, y='stack_1605' , na=T, X = cols, FUN = tab.auxfun)
+# lapply(tabs3, head)
+# table(df$stack_1605)
+
+# Only one respondent in employement did vote
+# for party 1605 (voted by only 8 respondents of the Latvian sample).
+
+# Model 5 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+mdl  <- 5
+df   <- regdf_lst$logit[[mdl]]
+cols <- 'EDU_rec'
+
+tabs4 <- lapply(data=df, y='stack_1610' , na=T, X = cols, FUN = tab.auxfun)
+# lapply(tabs4, head)
+# table(df$stack_1610)
+
+# Only one respondent with 15 years or less education did vote
+# for party 1610 (voted by 87 respondents of the Latvian sample).
+
+# Model 6 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+mdl  <- 6
+df   <- regdf_lst$logit[[mdl]]
+cols <- 'EDU_rec'
+
+tabs5 <- lapply(data=df, y='stack_1604' , na=T, X = cols, FUN = tab.auxfun)
+# lapply(tabs5, head)
+# table(df$stack_1604)
+
+# No respondent with 15 years or less education did vote
+# for party 1604 (voted by 40 respondents of the Latvian sample).
+
+# Model 7 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+mdl  <- 7
+df   <- regdf_lst$logit[[mdl]]
+cols <- c('EDU_rec', 'D6_une')
+
+tabs6 <- lapply(data=df, y='stack_1616', na=T, X = cols, FUN = tab.auxfun)
+# lapply(tabs6, head)
+# table(df$stack_1616)
+
+# One respondent with 15 years or less education and three unemployed did vote 
+# for party 1616 (voted 135 respondents of the Latvian sample).
 
 
 # Syntvars evaluation: partial logit models # ==========================================================
 
-# Case 1: Only exclusing EDU_rec as variable # - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Get the df for and estimate the partial models # - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+vrbls_2_drop <- 'EDU_rec' #for model 5,6
+vrbls_2_drop2 <- c('EDU_rec', 'D6_une') #for model 1,7
+vrbls_2_drop3 <- 'D5_rec' #for model 4
+vrbls_2_drop4 <- 'D6_une' #for model 2
 
 regdf_lst_part <- 
   regdf_lst$logit %>% 
-  lapply(., function(x){ x %<>% na.omit() %>% dplyr::select(-EDU_rec)})
+  lapply(., function(x){
+    x %<>% na.omit()
+  }) 
+
+regdf_lst_part[[1]] <- regdf_lst_part[[1]][,!(names(regdf_lst_part[[1]]) %in% vrbls_2_drop)]
+regdf_lst_part[[8]] <- regdf_lst_part[[1]][,!(names(regdf_lst_part[[1]]) %in% vrbls_2_drop2)]
+regdf_lst_part[[2]] <- regdf_lst_part[[2]][,!(names(regdf_lst_part[[2]]) %in% vrbls_2_drop4)]
+regdf_lst_part[[4]] <- regdf_lst_part[[4]][,!(names(regdf_lst_part[[4]]) %in% vrbls_2_drop3)]
+regdf_lst_part[[5]] <- regdf_lst_part[[5]][,!(names(regdf_lst_part[[5]]) %in% vrbls_2_drop)]
+regdf_lst_part[[6]] <- regdf_lst_part[[6]][,!(names(regdf_lst_part[[6]]) %in% vrbls_2_drop)]
+regdf_lst_part[[7]] <- regdf_lst_part[[7]][,!(names(regdf_lst_part[[7]]) %in% vrbls_2_drop)]
+
 
 partmod_lst <- 
   lapply(regdf_lst_part, function(x){
@@ -294,136 +396,93 @@ partmod_lst <-
 
 # LR test (Chisq) # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 
+mdls <- c(1,2,4,5,6,7)
+
 anova_lst <- 
-  anova.auxfun(mdl_lst1 = partmod_lst,
-               mdl_lst2 = fullmod_lst$logit,
+  anova.auxfun(mdl_lst1 = partmod_lst[c(mdls)],
+               mdl_lst2 = fullmod_lst$logit[c(mdls)],
                table = F)
-
-# lapply(anova_lst, head)
-#For Model 1,3,4,5,6 H0 can not be rejected
-#For Model 2 can reject at p<0.1 SN
-#For Model 7 can reject at p<0 SN. This is troublesome since also model7 shows large std. errors for EDU_rec. 
-#                                   Still excluding the variabel is not the "better" fit
-
-stargazer::stargazer(partmod_lst, type = 'text',
-                                            column.labels = as.character(relprty_df$Q7),
-                                            dep.var.labels = 'Vote choice',
-                                            star.cutoffs = c(0.05, 0.01, 0.001),
-                                            omit.stat=c("f", "ser"),
-                                            header = F,
-                                            style = 'ajps')
-
-#problem of high std. errors solved for all including Model7, but not for model4, however it decreased the constant std error
-
-
-# Partial models fit summary for  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-
-
-partlogit_df <-  
-  tibble(
-    'depvar'     = lapply(1:length(partmod_lst), 
-                          function(x){
-                            names(regdf_lst_part[[x]]) %>% .[2]
-                          }) %>% unlist,
-    'model'      = rep('partial',length(regdf_lst_part)),
-    'Ps_Rsq'     = lapply(1:length(partmod_lst),
-                          function(x){
-                            DescTools::PseudoR2(partmod_lst[[x]], which = 'McFadden')
-                          }) %>% unlist,
-    'Adj_Ps_Rsq' = lapply(1:length(partmod_lst),
-                          function(x){
-                            DescTools::PseudoR2(partmod_lst[[x]], which = 'McFaddenAdj')
-                          }) %>% unlist,
-    'AIC'        = lapply(1:length(partmod_lst),
-                          function(x) {
-                            partmod_lst[[x]] %>% AIC
-                          }) %>% unlist
-  ) %>% 
-  left_join(., relprty_df, by='depvar') %>% 
-  dplyr::select(depvar, partycode, partyname_eng, model,
-                Ps_Rsq, Adj_Ps_Rsq, AIC)
-
-
-# Case 2 excluding also other variables than EDU_rec # - - - - - - - - - - - - - - - - - - - - - - - - -
-# Get the df for and estimate the partial models # - - - - - - - - - - - - - - - - - - - - - - - - - - -
-
-regdf_lst_part2 <- 
-  regdf_lst$logit %>% 
-  lapply(., function(x){ x %<>% na.omit() %>% dplyr::select(-c(EDU_rec, D5_rec))})
-
-partmod_lst2 <- 
-  lapply(regdf_lst_part2, function(x){
-    y    <- names(x)[startsWith(names(x), 'stack')]
-    xs   <- names(x)[3:length(x)]
-    frml <- paste(y, paste0(xs, collapse = ' + '), sep = " ~ ") %>% as.formula
-    
-    fit <- glm(data = x, formula = frml, family = binomial)
-    
-    return(fit)
-  })
-
-# LR test (Chisq) # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 
 anova_lst2 <- 
-  anova.auxfun(mdl_lst1 = partmod_lst2,
-               mdl_lst2 = fullmod_lst$logit,
+  anova.auxfun(mdl_lst1 = partmod_lst[c(8)],
+               mdl_lst2 = fullmod_lst$logit[c(1)],
                table = F)
 
+
+# lapply(anova_lst, head)
 # lapply(anova_lst2, head)
-#For Model 1,2,3,4,5,6 H0 can not be rejected
-#For Model 7 can be rejected at p<0.001
 
-# stargazer::stargazer(partmod_lst2, type = 'text',
-#                                             column.labels = as.character(relprty_df$Q7),
-#                                             dep.var.labels = 'Vote choice',
-#                                             star.cutoffs = c(0.05, 0.01, 0.001),
-#                                             omit.stat=c("f", "ser"),
-#                                             header = F,
-#                                             style = 'ajps')
+# For Model 1 H0 can be rejected at p<0.05  (H0 can not be rejected if only EDU_rec is dropped instead of both EDU_rec & D6_une, no high SE constant)
+# We see that not dropping D6_une does not distort the SE of the constant, thus we like to drop as less variables as possible and include 
+# the partial model with only EDU_rec dropped for model 1.
+# For Model 2 H0 can be rejected at p<0.1
+# For Model 4 H0 can be rejected at p<0.05
+# For Model 5 H0 can be rejected at p<0.1
+# For Model 6 H0 can be rejected at p<0.05
+# For Model 7 H0 can be rejected at p<0.001 (H0 can be rejected at p<0.01 if only D6_une is dropped instead of both EDU_rec & D6_une, however than still high SE in constant)
 
-#problem of high std. errors solved for all models
-
-
-# Partial models fit summary for  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-
-
-partlogit_df2 <-  
-  tibble(
-    'depvar'     = lapply(1:length(partmod_lst2), 
-                          function(x){
-                            names(regdf_lst_part2[[x]]) %>% .[2]
-                          }) %>% unlist,
-    'model'      = rep('partial2',length(regdf_lst_part2)),
-    'Ps_Rsq'     = lapply(1:length(partmod_lst2),
-                          function(x){
-                            DescTools::PseudoR2(partmod_lst2[[x]], which = 'McFadden')
-                          }) %>% unlist,
-    'Adj_Ps_Rsq' = lapply(1:length(partmod_lst2),
-                          function(x){
-                            DescTools::PseudoR2(partmod_lst2[[x]], which = 'McFaddenAdj')
-                          }) %>% unlist,
-    'AIC'        = lapply(1:length(partmod_lst2),
-                          function(x) {
-                            partmod_lst2[[x]] %>% AIC
-                          }) %>% unlist
-  ) %>% 
-  left_join(., relprty_df, by='depvar') %>% 
-  dplyr::select(depvar, partycode, partyname_eng, model,
-                Ps_Rsq, Adj_Ps_Rsq, AIC)
+# stargazer::stargazer(partmod_lst, type = 'text',
+#                      column.labels = as.character(relprty_df$Q7),
+#                      dep.var.labels = 'Vote choice',
+#                      star.cutoffs = c(0.05, 0.01, 0.001),
+#                      omit.stat=c("f", "ser"),
+#                      header = F,
+#                      style = 'ajps')
 
 
-# Syntvars evaluation: New logit models fit stats # ====================================================
+# Syntvars evaluation: Updating logit models (and related data frames) lists # ===============================
 
-logit_df <-  
-  fulllogit_df %>% 
-  rbind(., partlogit_df) %>% 
-  rbind(., partlogit_df2) %>%
-  rbind(., nulllogit_df)
+# fullmod_lst$logit[c(mdls)] <- partmod_lst[c(mdls)]
+
+finalmod_lst <- list()
+finalmod_lst[['OLS']] <- fullmod_lst[['OLS']]
+finalmod_lst[['logit']] <- fullmod_lst[['logit']]
+
+finalmod_lst[['logit']][[8]] <- finalmod_lst[['logit']][[6]]
+finalmod_lst[['logit']][[9]] <- partmod_lst[[6]]
+finalmod_lst[['logit']][[10]] <- finalmod_lst[['logit']][[7]]
+finalmod_lst[['logit']][[5]] <- finalmod_lst[['logit']][[4]]
+finalmod_lst[['logit']][[6]] <- finalmod_lst[['logit']][[5]]
+finalmod_lst[['logit']][[7]] <- partmod_lst[[5]]
+finalmod_lst[['logit']][[4]] <- finalmod_lst[['logit']][[3]]
+finalmod_lst[['logit']][[3]] <- finalmod_lst[['logit']][[2]]
+finalmod_lst[['logit']][[2]] <- partmod_lst[[1]]
 
 
+# stargazer::stargazer(finalmod_lst$logit, type = 'text',
+#                      column.labels = as.character(relprty_df$Q7),
+#                      dep.var.labels = 'Vote choice',
+#                      star.cutoffs = c(0.05, 0.01, 0.001),
+#                      omit.stat=c("f", "ser"),
+#                      header = F,
+#                      style = 'ajps')
 
-# Clean the environment # ==============================================================================
 
-rm(list=ls(pattern='auxfun|regdf|partlogit|fulllogit|nulllogit'))
+# Syntvars evaluation: Updating AIC data frames (logit only) # =========================================
 
+# logit AIC df 
+
+logit_aic %<>% 
+  rbind(.,
+        tibble('depvar'    = 'stack_1611',
+               'partycode' = 1611, 
+               'full'      = partmod_lst[[1]] %>% AIC,
+               'null'      = nullmod_lst$logit[[1]] %>% AIC,
+        ) %>% 
+          mutate(diff = full-null)) %>% 
+  rbind(.,
+        tibble('depvar'    = 'stack_1610',
+               'partycode' = 1610, 
+               'full'      = partmod_lst[[5]] %>% AIC,
+               'null'      = nullmod_lst$logit[[5]] %>% AIC,
+        ) %>% 
+          mutate(diff = full-null)) %>%
+  rbind(.,
+        tibble('depvar'    = 'stack_1604',
+               'partycode' = 1604, 
+               'full'      = partmod_lst[[6]] %>% AIC,
+               'null'      = nullmod_lst$logit[[6]] %>% AIC,
+        ) %>% 
+          mutate(diff = full-null)) %>%
+  .[order(.$depvar, .$partycode),] 
 

--- a/Scripts/synteval_scripts/country_spec_scripts/EES2019_pt_synteval.R
+++ b/Scripts/synteval_scripts/country_spec_scripts/EES2019_pt_synteval.R
@@ -1,7 +1,7 @@
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Title: Script for Evaluating Synthetic Variables Estimation (EES 2019 Voter Study, Portuguese Sample) 
 # Author: M.Körnig
-# last update: 2021-10-28
+# last update: 2021-11-06
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 # Country-spec workflow # ==============================================================================
@@ -60,7 +60,7 @@ csdf_lst <- list('std'  = EES2019_pt,
 syntvars_vrbls <- list('dep'   = list('OLS'     = 'Q10_gen', 
                                       'logit'   = 'Q7_gen'),
                        'indep' = list('ctgrcl' = c('D3_rec', 'D8_rec',  'D5_rec', 'EDU_rec', 
-                                                   'D1_rec', 'D7_rec'),
+                                                   'D1_rec', 'D7_rec', 'D6_une'),
                                       'cntns'  =  c('D4_age', 'D10_rec')))
 
 
@@ -197,8 +197,7 @@ ols_df %<>%
 
 # Syntvars evaluation: logit models fit stats # ========================================================
 
-
-fulllogit_df <- 
+logit_df <- 
   tibble(
     'depvar'     = lapply(1:length(regdf_lst$logit), 
                           function(x){
@@ -218,47 +217,70 @@ fulllogit_df <-
                             fullmod_lst$logit[[x]] %>% AIC
                           }) %>% unlist
   ) %>% 
+  rbind(.,
+        tibble(
+          'depvar'     = lapply(1:length(regdf_lst$logit), 
+                                function(x){
+                                  names(regdf_lst$OLS[[x]]) %>% .[2]
+                                }) %>% unlist,
+          'model'      = rep('null',length(regdf_lst$logit)),
+          'Ps_Rsq'     = lapply(1:length(nullmod_lst$logit),
+                                function(x){
+                                  DescTools::PseudoR2(nullmod_lst$logit[[x]], which = 'McFadden')
+                                }) %>% unlist,
+          'Adj_Ps_Rsq' = lapply(1:length(nullmod_lst$logit),
+                                function(x){
+                                  DescTools::PseudoR2(nullmod_lst$logit[[x]], which = 'McFaddenAdj')
+                                }) %>% unlist,
+          'AIC'        = lapply(1:length(fullmod_lst$logit),
+                                function(x) {
+                                  nullmod_lst$logit[[x]] %>% AIC
+                                }) %>% unlist
+        ))
+
+
+logit_df %<>% 
   left_join(., relprty_df, by='depvar') %>% 
   dplyr::select(depvar, partycode, partyname_eng, model,
                 Ps_Rsq, Adj_Ps_Rsq, AIC)
 
 
+# AIC data frames # ====================================================================================
 
-nulllogit_df<- 
-  tibble(
-    'depvar'     = lapply(1:length(regdf_lst$logit), 
-                          function(x){
-                            names(regdf_lst$OLS[[x]]) %>% .[2]
-                          }) %>% unlist,
-    'model'      = rep('null',length(regdf_lst$logit)),
-    'Ps_Rsq'     = lapply(1:length(nullmod_lst$logit),
-                          function(x){
-                            DescTools::PseudoR2(nullmod_lst$logit[[x]], which = 'McFadden')
-                          }) %>% unlist,
-    'Adj_Ps_Rsq' = lapply(1:length(nullmod_lst$logit),
-                          function(x){
-                            DescTools::PseudoR2(nullmod_lst$logit[[x]], which = 'McFaddenAdj')
-                          }) %>% unlist,
-    'AIC'        = lapply(1:length(fullmod_lst$logit),
-                          function(x) {
-                            nullmod_lst$logit[[x]] %>% AIC
-                          }) %>% unlist
-  ) %>% 
-  left_join(., relprty_df, by='depvar') %>% 
-  dplyr::select(depvar, partycode, partyname_eng, model,
-                Ps_Rsq, Adj_Ps_Rsq, AIC)
+# OLS AIC df 
 
+ols_aic <- 
+  ols_df %>%
+  pivot_wider(id_cols = c('depvar', 'partycode', 'partyname_eng'), values_from = 'AIC',
+              names_from = 'model') %>%
+  mutate(diff = full - null) %>%
+  mutate(across(c('full', 'null', 'diff'), ~round(.,3))) %>%
+  dplyr::select(-c(partyname_eng))
 
-# Syntvars evaluation: New logit models fit stats # ====================================================
+# Logit AIC df 
 
-logit_df <-  
-  fulllogit_df %>% 
-  rbind(., nulllogit_df)
+logit_aic <- 
+  logit_df %>%
+  pivot_wider(id_cols = c('depvar', 'partycode', 'partyname_eng'), values_from = 'AIC',
+              names_from = 'model') %>%
+  mutate(diff = full - null) %>%
+  mutate(across(c('full', 'null', 'diff'), ~round(.,3))) %>%
+  dplyr::select(-c(partyname_eng))
 
 
 
-# Clean the environment # ==============================================================================
+# Full models evaluation # =============================================================================
 
-rm(list=ls(pattern='auxfun|regdf|partlogit|fulllogit|nulllogit'))
+# logit model shows no inflated SE on predictors nor constant
+
+
+
+# Syntvars evaluation: Updating logit models (and related data frames) lists # ===============================
+
+# fullmod_lst$logit[c(mdls)] <- partmod_lst[c(mdls)]
+
+finalmod_lst <- list()
+finalmod_lst[['OLS']] <- fullmod_lst[['OLS']]
+finalmod_lst[['logit']] <- fullmod_lst[['logit']]
 
 

--- a/Scripts/synteval_scripts/country_spec_scripts/EES2019_ro_synteval.R
+++ b/Scripts/synteval_scripts/country_spec_scripts/EES2019_ro_synteval.R
@@ -1,7 +1,7 @@
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Title: Script for Evaluating Synthetic Variables Estimation (EES 2019 Voter Study, Romanian Sample) 
 # Author: M.Körnig
-# last update: 2021-10-28
+# last update: 2021-11-06
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 # Country-spec workflow # ==============================================================================
@@ -68,7 +68,7 @@ csdf_lst <- list('std'  = EES2019_ro,
 syntvars_vrbls <- list('dep'   = list('OLS'     = 'Q10_gen', 
                                       'logit'   = 'Q7_gen'),
                        'indep' = list('ctgrcl' = c('D3_rec', 'D8_rec',  'D5_rec', 'EDU_rec', 
-                                                   'D1_rec', 'D7_rec'),
+                                                   'D1_rec', 'D7_rec', 'D6_une'),
                                       'cntns'  =  c('D4_age', 'D10_rec')))
 
 
@@ -142,15 +142,15 @@ nullmod_lst <- list('OLS'   = lapply(X = regdf_lst$OLS,   regmod = 'OLS',   null
 
 # Syntvars evaluation: logit models summary # ==========================================================
 
-stargazer::stargazer(fullmod_lst$logit, type = 'text',
-                     column.labels = as.character(relprty_df$Q7),
-                     dep.var.labels = 'Vote choice',
-                     star.cutoffs = c(0.05, 0.01, 0.001),
-                     omit.stat=c("f", "ser"),
-                     header = F,
-                     style = 'ajps')
+# stargazer::stargazer(fullmod_lst$logit, type = 'text',
+#                      column.labels = as.character(relprty_df$Q7),
+#                      dep.var.labels = 'Vote choice',
+#                      star.cutoffs = c(0.05, 0.01, 0.001),
+#                      omit.stat=c("f", "ser"),
+#                      header = F,
+#                      style = 'ajps')
 
-#large std. errors in Logit Model5: EDU_rec, constant
+#large std. errors in Logit Model5: EDU_rec, D6_une, constant
 
 # Syntvars evaluation: OLS models fit stats # ==========================================================
 
@@ -205,8 +205,7 @@ ols_df %<>%
 
 # Syntvars evaluation: logit models fit stats # ========================================================
 
-
-fulllogit_df <- 
+logit_df <- 
   tibble(
     'depvar'     = lapply(1:length(regdf_lst$logit), 
                           function(x){
@@ -226,61 +225,98 @@ fulllogit_df <-
                             fullmod_lst$logit[[x]] %>% AIC
                           }) %>% unlist
   ) %>% 
+  rbind(.,
+        tibble(
+          'depvar'     = lapply(1:length(regdf_lst$logit), 
+                                function(x){
+                                  names(regdf_lst$OLS[[x]]) %>% .[2]
+                                }) %>% unlist,
+          'model'      = rep('null',length(regdf_lst$logit)),
+          'Ps_Rsq'     = lapply(1:length(nullmod_lst$logit),
+                                function(x){
+                                  DescTools::PseudoR2(nullmod_lst$logit[[x]], which = 'McFadden')
+                                }) %>% unlist,
+          'Adj_Ps_Rsq' = lapply(1:length(nullmod_lst$logit),
+                                function(x){
+                                  DescTools::PseudoR2(nullmod_lst$logit[[x]], which = 'McFaddenAdj')
+                                }) %>% unlist,
+          'AIC'        = lapply(1:length(fullmod_lst$logit),
+                                function(x) {
+                                  nullmod_lst$logit[[x]] %>% AIC
+                                }) %>% unlist
+        ))
+
+
+logit_df %<>% 
   left_join(., relprty_df, by='depvar') %>% 
   dplyr::select(depvar, partycode, partyname_eng, model,
                 Ps_Rsq, Adj_Ps_Rsq, AIC)
 
 
+# AIC data frames # ====================================================================================
 
-nulllogit_df<- 
-  tibble(
-    'depvar'     = lapply(1:length(regdf_lst$logit), 
-                          function(x){
-                            names(regdf_lst$OLS[[x]]) %>% .[2]
-                          }) %>% unlist,
-    'model'      = rep('null',length(regdf_lst$logit)),
-    'Ps_Rsq'     = lapply(1:length(nullmod_lst$logit),
-                          function(x){
-                            DescTools::PseudoR2(nullmod_lst$logit[[x]], which = 'McFadden')
-                          }) %>% unlist,
-    'Adj_Ps_Rsq' = lapply(1:length(nullmod_lst$logit),
-                          function(x){
-                            DescTools::PseudoR2(nullmod_lst$logit[[x]], which = 'McFaddenAdj')
-                          }) %>% unlist,
-    'AIC'        = lapply(1:length(fullmod_lst$logit),
-                          function(x) {
-                            nullmod_lst$logit[[x]] %>% AIC
-                          }) %>% unlist
-  ) %>% 
-  left_join(., relprty_df, by='depvar') %>% 
-  dplyr::select(depvar, partycode, partyname_eng, model,
-                Ps_Rsq, Adj_Ps_Rsq, AIC)
+# OLS AIC df 
+
+ols_aic <- 
+  ols_df %>%
+  pivot_wider(id_cols = c('depvar', 'partycode', 'partyname_eng'), values_from = 'AIC',
+              names_from = 'model') %>%
+  mutate(diff = full - null) %>%
+  mutate(across(c('full', 'null', 'diff'), ~round(.,3))) %>%
+  dplyr::select(-c(partyname_eng))
+
+# Logit AIC df 
+
+logit_aic <- 
+  logit_df %>%
+  pivot_wider(id_cols = c('depvar', 'partycode', 'partyname_eng'), values_from = 'AIC',
+              names_from = 'model') %>%
+  mutate(diff = full - null) %>%
+  mutate(across(c('full', 'null', 'diff'), ~round(.,3))) %>%
+  dplyr::select(-c(partyname_eng))
+
+
+
+# Full models evaluation # =============================================================================
+
+# logit model 5 shows inflated SE on some predictors, more specifically: 
+# Model 5: EDU_rec, D6_une
+
+# Model 5  constant is affected showing unusual values. We deal only with model 5 affected 
+# by separation issue.
 
 
 # Syntvars evaluation: evaluating the source of misfit # ===============================================
 
+# Model 5 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 
-# One contingency table #model5, EDU_rec
-df <- regdf_lst$logit[[5]]
-tabEDU_rec <- table(df$stack_2307, df$EDU_rec) %>% as.data.frame()
-names(tabEDU_rec)[1:2] <- c('stack_2307', 'EDU_rec')
-# Problem: no one voted for party 2307 (Hungarian Democratic Alliance of Romania) and has 15 years of education or less
+mdl  <- 5
+df   <- regdf_lst$logit[[mdl]]
+cols <- c('EDU_rec', 'D6_une')
 
-# All the contingency tables # 
+tabs <- lapply(data=df, y='stack_2307', na=T, X = cols, FUN = tab.auxfun)
+#lapply(tabs, head)
+#table(df$stack_2307)
 
-tabs <- yxcontab.auxfun(regdf_lst$logit[[5]], contab = F)
+# No respondents with 15 years or less education and in employment did vote 
+# for party 2307 (voted by only 28 respondents of the Romanian sample).
 
-# look at elements of tabs list
-# lapply(tabs, head)
 
 
 # Syntvars evaluation: partial logit models # ==========================================================
 
 # Get the df for and estimate the partial models # - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
+vrbls_2_drop <- c('EDU_rec')
+vrbls_2_drop2 <- c('D6_une')
+
 regdf_lst_part <- 
   regdf_lst$logit %>% 
-  lapply(., function(x){ x %<>% na.omit() %>% dplyr::select(-EDU_rec)})
+  lapply(., function(x){
+    x %<>% na.omit() %>% dplyr::select(-c(all_of(vrbls_2_drop)))
+  }) 
+
+regdf_lst_part[[8]] <- regdf_lst_part[[5]][,!(names(regdf_lst_part[[5]]) %in% vrbls_2_drop2)]
 
 partmod_lst <- 
   lapply(regdf_lst_part, function(x){
@@ -295,66 +331,61 @@ partmod_lst <-
 
 # LR test (Chisq) # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 
+mdls <- c(5)
+
 anova_lst <- 
-  anova.auxfun(mdl_lst1 = partmod_lst,
-               mdl_lst2 = fullmod_lst$logit,
+  anova.auxfun(mdl_lst1 = partmod_lst[c(mdls)],
+               mdl_lst2 = fullmod_lst$logit[c(mdls)],
                table = F)
 
-# lapply(anova_lst, head)
+anova_lst2 <- 
+  anova.auxfun(mdl_lst1 = partmod_lst[c(8)],
+               mdl_lst2 = fullmod_lst$logit[c(5)],
+               table = F)
 
-#For Model 1,2,3,4,5,6 H0 can not be rejected
-#For Model 7 H0 can be rejected at p<0
+
+# lapply(anova_lst, head)
+# lapply(anova_lst2, head)
+
+# For Model 5 H0 can be rejected at p<0.001 (H0 can not be rejected if only EDU_rec is dropped, high SE for constant also vanishes)
+# Thus, we include only the partial model with EDU_rec dropped, since the high SE of D6_une does not affect the constant
+
 
 # stargazer::stargazer(partmod_lst, type = 'text',
-#                                             column.labels = as.character(relprty_df$Q7),
-#                                             dep.var.labels = 'Vote choice',
-#                                             star.cutoffs = c(0.05, 0.01, 0.001),
-#                                             omit.stat=c("f", "ser"),
-#                                             header = F,
-#                                             style = 'ajps')
-
-#problem of high std. errors solved for model5
+#                      column.labels = as.character(relprty_df$Q7),
+#                      dep.var.labels = 'Vote choice',
+#                      star.cutoffs = c(0.05, 0.01, 0.001),
+#                      omit.stat=c("f", "ser"),
+#                      header = F,
+#                      style = 'ajps')
 
 
-# Partial models fit summary # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Syntvars evaluation: Updating logit models (and related data frames) lists # ===============================
 
+# fullmod_lst$logit[c(mdls)] <- partmod_lst[c(mdls)]
 
-partlogit_df <-  
-  tibble(
-    'depvar'     = lapply(1:length(partmod_lst), 
-                          function(x){
-                            names(regdf_lst_part[[x]]) %>% .[2]
-                          }) %>% unlist,
-    'model'      = rep('partial',length(regdf_lst_part)),
-    'Ps_Rsq'     = lapply(1:length(partmod_lst),
-                          function(x){
-                            DescTools::PseudoR2(partmod_lst[[x]], which = 'McFadden')
-                          }) %>% unlist,
-    'Adj_Ps_Rsq' = lapply(1:length(partmod_lst),
-                          function(x){
-                            DescTools::PseudoR2(partmod_lst[[x]], which = 'McFaddenAdj')
-                          }) %>% unlist,
-    'AIC'        = lapply(1:length(partmod_lst),
-                          function(x) {
-                            partmod_lst[[x]] %>% AIC
-                          }) %>% unlist
-  ) %>% 
-  left_join(., relprty_df, by='depvar') %>% 
-  dplyr::select(depvar, partycode, partyname_eng, model,
-                Ps_Rsq, Adj_Ps_Rsq, AIC)
+finalmod_lst <- list()
+finalmod_lst[['OLS']] <- fullmod_lst[['OLS']]
+finalmod_lst[['logit']] <- fullmod_lst[['logit']]
 
-
-# Syntvars evaluation: New logit models fit stats # ====================================================
-
-logit_df <-  
-  fulllogit_df %>% 
-  rbind(., partlogit_df) %>% 
-  rbind(., nulllogit_df)
+finalmod_lst[['logit']][[8]] <- finalmod_lst[['logit']][[7]]
+finalmod_lst[['logit']][[7]] <- finalmod_lst[['logit']][[6]]
+finalmod_lst[['logit']][[6]] <- partmod_lst[[mdls]] 
 
 
 
-# Clean the environment # ==============================================================================
+# Syntvars evaluation: Updating AIC data frames (logit only) # =========================================
 
-rm(list=ls(pattern='auxfun|regdf|partlogit|fulllogit|nulllogit'))
+# logit AIC df 
+
+logit_aic %<>% 
+  rbind(.,
+        tibble('depvar'    = 'stack_2307',
+               'partycode' = 2307, 
+               'full'      = partmod_lst[[mdls]] %>% AIC,
+               'null'      = nullmod_lst$logit[[mdls]] %>% AIC,
+        ) %>% 
+          mutate(diff = full-null)) %>% 
+  .[order(.$depvar, .$partycode),] 
 
 


### PR DESCRIPTION
Two Things to say here. Some full login tables (the very last tables at each Codebook section) are too wide. Thus, I implemented two different solutions:

1)For Croatia and Slovenia I splitted the Table in half and displayed two Tables. This worked very well
2)For others I just adjusted the Font Size. Here however problems occurred. Whenever I adjusted the font size, the gsub command to rename the models wouldn't work anymore. Still in my opinion it was a bit too radical to split also these lightly too large tables in half. 

Let me know, how you want it to be adjusted, and I will gladly update the R-Markdown File