### PR TITLE
Updated aux_scripts to include emcs variable

### DIFF
--- a/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_be.R
+++ b/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_be.R
@@ -1,7 +1,7 @@
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Title: EES2019 enhanced codebook (Belgian sample)
-# Author: G.Carteny
-# last update: 2021-08-30
+# Author: G.Carteny & J.Leiser
+# last update: 2022-03-15
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 
@@ -58,6 +58,40 @@ EES2019_be_enhcdbk <-
 # EES2019_be_enhcdbk %>%
 #   dplyr::select(partyname, partyname_eng, Q7, votesh, seats) %>%
 #   print(., n=nrow(.))
+
+# Create a common variable for merging the codebook w/ EMCS # ==========================================
+
+# EES2019_be_enhcdbk %>%
+#   dplyr::select(partyname, partyname_eng, Q7) %>%
+#   print(., n=nrow(.))
+
+EES2019_be_enhcdbk %<>% 
+  mutate(
+    emcs = case_when(
+      Q7==207 ~ 21201,  # Workers Party of Belgium 
+      Q7==201 ~ 21521,  # Christian Democratic and Flemish Party
+      Q7==204 ~ 21321,  # Socialist Party Different
+      Q7==206 ~ 21421,  # Open Flemish Liberals and Democrats
+      Q7==203 ~ 21913,  # New Flemish Alliance  
+      Q7==202 ~ 21112,  # Green
+      Q7==205 ~ 21914,  # Flemish Interest 
+      Q7==208 ~ 21322,  # Francophone Socialist Party 
+      Q7==209 ~ 21427,  # Reform Movement
+      Q7==210 ~ 21522,  # Humanist Democratic Centre 
+      Q7==211 ~ 21111,  # Ecologists
+      Q7==212 ~ NA_real_,  # National Front (Belgium)
+      Q7==213 ~ 21201,  # Workers Party of Belgium
+      Q7==214 ~ NA_real_,  #  Francophone Democratic Federalists
+      T       ~ NA_real_
+    ),
+    emcs = as.integer(emcs)
+  )
+
+# Check the new dataset 
+
+# EES2019_be_enhcdbk %>%
+#   dplyr::select(partyname, partyname_eng, Q7, emcs)
+
 
 # Clean the environment # ==============================================================================
 

--- a/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_bg.R
+++ b/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_bg.R
@@ -1,7 +1,7 @@
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Title: EES2019 enhanced codebook (Bulgarian sample)
-# Author: G.Carteny
-# last update: 2021-08-23
+# Author: G.Carteny & J.Leiser
+# last update: 2022-03-15
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 
@@ -59,6 +59,34 @@ EES2019_bg_enhcdbk <-
 
 # EES2019_bg_enhcdbk %>%
 #   dplyr::select(partyname, partyname_eng, Q7, votesh, seats)
+
+# Create a common variable for merging the codebook w/ EMCS # ==========================================
+
+# EES2019_bg_enhcdbk %>%
+#   dplyr::select(partyname, partyname_eng, Q7) %>%
+#   print(., n=nrow(.))
+
+EES2019_bg_enhcdbk %<>% 
+  mutate(
+    emcs = case_when(
+      Q7==301 ~ 80620,  # Citzizens for European Development of Bulgaria (GERB) 
+      Q7==302 ~ NA_real_,  # Coalition for Bulgaria (KB)
+      Q7==303 ~ 80420,  # Movements for Rights and Freedoms (DPS)
+      Q7==304 ~ NA_real_,  # IMRO – Bulgarian National Movement
+      Q7==305 ~ 80602,  # Democratic Bulgaria  
+      Q7==306 ~ NA_real_,  # Will
+      Q7==307 ~ 80710,  # National Union Attack (ATAKA/ATA)
+      Q7==308 ~ NA_real_,  # National Front for the Salvation of Bulgaria
+      Q7==309 ~ NA_real_,  # Alternative for Bulgarian Revival 
+      T       ~ NA_real_
+    ),
+    emcs = as.integer(emcs)
+  )
+
+# Check the new dataset 
+
+# EES2019_bg_enhcdbk %>%
+#   dplyr::select(partyname, partyname_eng, Q7, emcs)
 
 # Clean the environment # ==============================================================================
 

--- a/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_cz.R
+++ b/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_cz.R
@@ -1,7 +1,7 @@
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Title: EES2019 enhanced codebook (Czech Rep. sample)
 # Author: J.Leiser
-# last update: 2021-08-25
+# last update: 2022-03-15
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 
@@ -48,6 +48,35 @@ EES2019_cz_enhcdbk <-
 
 # EES2019_cz_enhcdbk %>% 
 #   dplyr::select(partyname, partyname_eng, Q7, votesh, seats)
+
+# Create a common variable for merging the codebook w/ EMCS # ==========================================
+
+# EES2019_cz_enhcdbk %>%
+#   dplyr::select(partyname, partyname_eng, Q7) %>%
+#   print(., n=nrow(.))
+
+EES2019_cz_enhcdbk %<>% 
+  mutate(
+    emcs = case_when(
+      Q7==601 ~ 82523,  # KDU/CSL 
+      Q7==603 ~ 82320,  # CSSD
+      Q7==604 ~ 82413,  # ODS
+      Q7==605 ~ 82220,  # KSCM
+      Q7==606 ~ 82414,  # ANO  
+      Q7==607 ~ 82403,  # Pirati
+      Q7==608 ~ 82701,  # SPD
+      Q7==602 ~ 82610,  # TOP 09
+      T       ~ NA_real_
+    ),
+    emcs = as.integer(emcs)
+  )
+
+# Check the new dataset 
+
+# EES2019_cz_enhcdbk %>%
+#   dplyr::select(partyname, partyname_eng, Q7, emcs)
+
+
 
 # Clean the environment # ==============================================================================
 

--- a/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_de.R
+++ b/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_de.R
@@ -1,7 +1,7 @@
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Title: EES2019 enhanced codebook (Germany sample)
-# Author: W. Haeussling
-# last update: 2021-08-27
+# Author: W. Haeussling & J.Leiser
+# last update: 2022-03-15
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 
@@ -54,6 +54,35 @@ EES2019_de_enhcdbk <-
 
 #EES2019_de_enhcdbk %>% 
 #   dplyr::select(partyname, partyname_eng, Q7, votesh, seats)
+
+
+# Create a common variable for merging the codebook w/ EMCS # ==========================================
+
+EES2019_de_enhcdbk %>%
+  dplyr::select(partyname, partyname_eng, Q7) %>%
+  print(., n=nrow(.))
+
+EES2019_de_enhcdbk %<>% 
+  mutate(
+    emcs = case_when(
+      Q7==801 ~ 41501,  # Christian Democratic Union / Christian Social Unio
+      Q7==802 ~ 41320,  # Sozialdemokratische Partei Deutschlands (SPD) 
+      Q7==805 ~ 41420,  # Free Democratic Party
+      Q7==803 ~ 41113,  # Alliance 90 / The Greens  
+      Q7==804 ~ 41221,  # The Left 
+      Q7==807 ~ 41950,  # Alternative for Germany
+      Q7==806 ~ 41951,  # Pirates 
+      T       ~ NA_real_
+    ),
+    emcs = as.integer(emcs)
+  )
+
+# Check the new dataset 
+
+# EES2019_de_enhcdbk %>%
+#   dplyr::select(partyname, partyname_eng, Q7, emcs)
+
+
 
 # Clean the environment # ==============================================================================
 

--- a/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_dk.R
+++ b/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_dk.R
@@ -1,7 +1,7 @@
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Title: EES2019 enhanced codebook (Denmark sample)
-# Author: W. Haeussling
-# last update: 2021-08-27
+# Author: W. Haeussling & J.Leiser
+# last update: 2022-03-15
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 
@@ -65,6 +65,36 @@ EP2019_dk[10,7] <- NA
 
 #EES2019_dk_enhcdbk %>% 
 #   dplyr::select(partyname, partyname_eng, Q7, votesh, seats)
+
+# Create a common variable for merging the codebook w/ EMCS # ==========================================
+
+# EES2019_dk_enhcdbk %>%
+#   dplyr::select(partyname, partyname_eng, Q7) %>%
+#   print(., n=nrow(.))
+
+EES2019_dk_enhcdbk %<>% 
+  mutate(
+    emcs = case_when(
+      Q7==701 ~ 13320,  # Social Democratic Party
+      Q7==702 ~ 13420,  # Liberals
+      Q7==703 ~ 13710,  # Danish People's Party
+      Q7==704 ~ 13410,  # Radical Party
+      Q7==705 ~ 13230,  # Socialist People's Party 
+      Q7==706 ~ 13201,  # Red-Green Unity List
+      Q7==707 ~ 13620,  # Conservative People's Party  
+      Q7==708 ~ NA_real_,  # Liberal Alliance
+      Q7==709 ~ 13954,  # People's Movement against the EU 
+      T       ~ NA_real_
+    ),
+    emcs = as.integer(emcs)
+  )
+
+# Check the new dataset 
+
+# EES2019_dk_enhcdbk %>%
+#   dplyr::select(partyname, partyname_eng, Q7, emcs)
+
+
 
 # Clean the environment # ==============================================================================
 

--- a/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_hr.R
+++ b/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_hr.R
@@ -1,7 +1,7 @@
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Title: EES2019 enhanced codebook (Croatian sample)
-# Author: G.Carteny
-# last update: 2021-08-30
+# Author: G.Carteny & J.Leiser
+# last update: 2022-03-15
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 
@@ -59,6 +59,41 @@ EES2019_hr_enhcdbk <-
 # EES2019_hr_enhcdbk %>%
 #   dplyr::select(partyname, partyname_eng, Q7, votesh, seats) %>% 
 #   print(., n=nrow(.))
+
+
+# Create a common variable for merging the codebook w/ EMCS # ==========================================
+
+# EES2019_hr_enhcdbk %>%
+#   dplyr::select(partyname, partyname_eng, Q7) %>%
+#   print(., n=nrow(.))
+
+EES2019_hr_enhcdbk %<>% 
+  mutate(
+    emcs = case_when(
+      Q7==412 ~ 81301,  # Social Democratic Party of Croatia  
+      Q7==404 ~ 81501,  # Croation Democratic Union
+      Q7==414 ~ 81001,  # Human Shield/Zivi Zid
+      Q7==405 ~ 81403,  # Amsterdamska koalicija
+      Q7==406 ~ 81601,  # Bridge of Independent Lists 
+      Q7==413 ~ 81402,  # START
+      Q7==401 ~ NA_real_,  # Bandi? Milan 365
+      Q7==402 ~ 81701,  # Coaltion of NHR (1191714) and HSP(1191713) 
+      Q7==403 ~ NA_real_,  # Croatian Growth
+      Q7==407 ~ NA_real_,  # MOZ?EMO
+      Q7==408 ~ NA_real_,  # NEZAVISNA LISTA MARIJANA PETIR
+      Q7==409 ~ 81002,  # NEZAVISNA LISTA MISLAV KOLAKUSI?
+      Q7==410 ~ NA_real_,  # PAMETNO + UNIJA KVARNERA
+      Q7==411 ~ NA_real_,  #  Independent Democratic Serbian Party  
+      T       ~ NA_real_
+    ),
+    emcs = as.integer(emcs)
+  )
+
+# Check the new dataset 
+
+# EES2019_hr_enhcdbk %>%
+#   dplyr::select(partyname, partyname_eng, Q7, emcs) %>% print(n = nrow(.))
+
 
 # Clean the environment # ==============================================================================
 

--- a/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_hu.R
+++ b/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_hu.R
@@ -1,7 +1,7 @@
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Title: EES2019 enhanced codebook (Hungary sample)
 # Author: J.Leiser
-# last update: 2021-08-26
+# last update: 2022-03-15
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 
@@ -47,6 +47,34 @@ EES2019_hu_enhcdbk <-
 
 # EES2019_hu_enhcdbk %>%
 #   dplyr::select(partyname, partyname_eng, Q7, votesh, seats)
+
+# Create a common variable for merging the codebook w/ EMCS # ==========================================
+
+# EES2019_hu_enhcdbk %>%
+#   dplyr::select(partyname, partyname_eng, Q7) %>%
+#   print(., n=nrow(.))
+
+EES2019_hu_enhcdbk %<>% 
+  mutate(
+    emcs = case_when(
+      Q7==1301 ~ 86310,  # DK
+      Q7==1302 ~ 86524,  # FIDESZ-KDNP
+      Q7==1303 ~ 86701,  # JOBBIK
+      Q7==1304 ~ 86120,  # LMP
+      Q7==1306 ~ 86220,  # MSZP  
+      Q7==1307 ~ NA_real_,  # MH
+      Q7==1308 ~ 86951,  # Momentum Mozgalom  
+      Q7==1305 ~ NA_real_,  # MKKP
+      T       ~ NA_real_
+    ),
+    emcs = as.integer(emcs)
+  )
+
+# Check the new dataset 
+
+# EES2019_hu_enhcdbk %>%
+#   dplyr::select(partyname, partyname_eng, Q7, emcs)
+
 
 # Clean the environment # ==============================================================================
 

--- a/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_ie.R
+++ b/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_ie.R
@@ -1,7 +1,7 @@
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Title: EES2019 enhanced codebook (Irish sample)
-# Author: M.Koernig
-# last update: 2021-08-27
+# Author: M.Koernig & J.Leiser
+# last update: 2022-03-16
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 
@@ -50,6 +50,35 @@ EES2019_ie_enhcdbk <-
 
 # EES2019_ie_enhcdbk %>% 
 #   dplyr::select(partyname, partyname_eng, Q7, votesh, seats)
+
+# Create a common variable for merging the codebook w/ EMCS # ==========================================
+
+# EES2019_ie_enhcdbk %>%
+#   dplyr::select(partyname, partyname_eng, Q7) %>%
+#   print(., n=nrow(.))
+
+EES2019_ie_enhcdbk %<>% 
+  mutate(
+    emcs = case_when(
+      Q7==1402 ~ 53520,  # Fine Gael 
+      Q7==1403 ~ 53320,  # Labour Party 
+      Q7==1401 ~ 53620,  # Fianna Fail 
+      Q7==1404 ~ 53110,  # Green Party 
+      Q7==1405 ~ 53951,  # Sinn Fein 
+      Q7==1406 ~ NA_real_,  # Solidarity - People Before Profit
+      Q7==1407 ~ 53301,  # Social Democrats 
+      Q7==1408 ~ 53302,  # Independents 4 Change
+      Q7==1409 ~ NA_real_,  # Independent
+      T       ~ NA_real_
+    ),
+    emcs = as.integer(emcs)
+  )
+
+# Check the new dataset 
+
+# EES2019_ie_enhcdbk %>%
+#   dplyr::select(partyname, partyname_eng, Q7, emcs)
+
 
 # Clean the environment # ==============================================================================
 

--- a/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_lv.R
+++ b/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_lv.R
@@ -1,7 +1,7 @@
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Title: EES2019 enhanced codebook (Latvian sample)
-# Author: M.Koernig
-# last update: 2021-08-27
+# Author: M.Koernig & J.Leiser
+# last update: 2022-03-16
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 
@@ -58,6 +58,44 @@ EES2019_lv_enhcdbk <-
 
 # EES2019_lv_enhcdbk %>% 
 #   dplyr::select(partyname, partyname_eng, Q7, votesh, seats)
+
+
+# Create a common variable for merging the codebook w/ EMCS # ==========================================
+
+# EES2019_lv_enhcdbk %>%
+#   dplyr::select(partyname, partyname_eng, Q7) %>%
+#   print(., n=nrow(.))
+
+EES2019_lv_enhcdbk %<>% 
+  mutate(
+    emcs = case_when(
+      Q7==1611 ~ 87710,  # For Fatherland and Freedom - National Independence Movement of Latvia 
+      Q7==1608 ~ NA_real_,  # New Conservative Party
+      Q7==1609 ~ 87401,  # Development/For!
+      Q7==1605 ~ NA_real_,  # Who owns the state?
+      Q7==1610 ~ 87221,  # Social Democratic Party \"\"Harmony\"\
+      Q7==1604 ~ 87110,  # Green and Farmers' Union
+      Q7==1616 ~ 87402,  # Unity
+      Q7==1601 ~ 87951,  # Latvian Russian Union 
+      Q7==1602 ~ NA_real_,  # Latvian Nationalists
+      Q7==1603 ~ NA_real_,  # Latvian Association of Regions 
+      Q7==1606 ~ NA_real_,  # Progressives
+      Q7==1607 ~ NA_real_,  # New Harmony
+      Q7==1612 ~ NA_real_,  # Action Party
+      Q7==1613 ~ NA_real_,  #  Awakening
+      Q7==1614 ~ NA_real_,  # Center Party
+      Q7==1615 ~ NA_real_,  # Latvian Social Democratic Workers' Party
+      T       ~ NA_real_
+    ),
+    emcs = as.integer(emcs)
+  )
+
+# Check the new dataset 
+
+# EES2019_lv_enhcdbk %>%
+#   dplyr::select(partyname, partyname_eng, Q7, emcs)
+
+
 
 # Clean the environment # ==============================================================================
 

--- a/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_mt.R
+++ b/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_mt.R
@@ -1,7 +1,7 @@
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Title: EES2019 enhanced codebook (Malta sample)
-# Author: W. Haeussling
-# last update: 2021-08-27
+# Author: W. Haeussling & J.Leiser
+# last update: 2022-03-16
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 
@@ -48,6 +48,32 @@ EES2019_mt_enhcdbk <-
 
 #EES2019_mt_enhcdbk %>% 
 #   dplyr::select(partyname, partyname_eng, Q7, votesh, seats)
+
+
+# Create a common variable for merging the codebook w/ EMCS # ==========================================
+
+# EES2019_mt_enhcdbk %>%
+#   dplyr::select(partyname, partyname_eng, Q7) %>%
+#   print(., n=nrow(.))
+
+EES2019_mt_enhcdbk %<>% 
+  mutate(
+    emcs = case_when(
+      Q7==1901 ~ 37320,  # Partit Laburista  
+      Q7==1902 ~ 37520,  # Partit Nazzjonalista
+      Q7==1903 ~ NA_real_,  # Alternattiva Demokratika
+      Q7==1904 ~ NA_real_,  # Partit Demokratiku
+      Q7==1905 ~ NA_real_,  # Imperu Ewropew 
+      T       ~ NA_real_
+    ),
+    emcs = as.integer(emcs)
+  )
+
+# Check the new dataset 
+
+# EES2019_mt_enhcdbk %>%
+#   dplyr::select(partyname, partyname_eng, Q7, emcs)
+
 
 # Clean the environment # ==============================================================================
 

--- a/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_pt.R
+++ b/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_pt.R
@@ -1,7 +1,7 @@
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Title: EES2019 enhanced codebook (Portuguese sample)
-# Author: M.Koernig
-# last update: 2021-08-27
+# Author: M.Koernig & J.Leiser
+# last update: 2022-03-16
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 
@@ -49,6 +49,34 @@ EES2019_pt_enhcdbk <-
 
 # EES2019_pt_enhcdbk %>% 
 #   dplyr::select(partyname, partyname_eng, Q7, votesh, seats)
+
+# Create a common variable for merging the codebook w/ EMCS # ==========================================
+
+# EES2019_pt_enhcdbk %>%
+#   dplyr::select(partyname, partyname_eng, Q7) %>%
+#   print(., n=nrow(.))
+
+EES2019_pt_enhcdbk %<>% 
+  mutate(
+    emcs = case_when(
+      Q7==2202 ~ 35319,  # Partido Social Democrata  (PSD) 
+      Q7==2204 ~ 35314,  # Centro Democratico e Social - Partido Popular (CDS-PP)
+      Q7==2201 ~ 35311,  # Partido Socialista (PS)
+      Q7==2203 ~ 35225,  # Coligacao Democratica Unitaria (CDU)  
+      Q7==2206 ~ 35223,  # Bloco de Esquerda (BE)  
+      Q7==2208 ~ 35101,  # Pessoas, Animais, Natureza (PAN) 
+      Q7==2205 ~ NA_real_,  # Partido da Terra (MPT) 
+      Q7==2207 ~ NA_real_,  # Partido Democratico Republicano (PDR) 
+      Q7==2209 ~ 35601,  # Alianca  
+      T       ~ NA_real_
+    ),
+    emcs = as.integer(emcs)
+  )
+
+# Check the new dataset 
+
+# EES2019_pt_enhcdbk %>%
+#   dplyr::select(partyname, partyname_eng, Q7, emcs)
 
 # Clean the environment # ==============================================================================
 

--- a/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_si.R
+++ b/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_si.R
@@ -1,7 +1,7 @@
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Title: EES2019 enhanced codebook (SLovenian sample)
-# Author: M.Koernig
-# last update: 2021-08-27
+# Author: M.Koernig & J.Leiser
+# last update: 2022-03-16
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 
@@ -54,6 +54,40 @@ EES2019_si_enhcdbk <-
 
 # EES2019_si_enhcdbk %>% 
 #   dplyr::select(partyname, partyname_eng, Q7, votesh, seats)
+
+
+# Create a common variable for merging the codebook w/ EMCS # ==========================================
+
+# EES2019_si_enhcdbk %>%
+#   dplyr::select(partyname, partyname_eng, Q7) %>%
+#   print(., n=nrow(.))
+
+EES2019_si_enhcdbk %<>% 
+  mutate(
+    emcs = case_when(
+      Q7==2401 ~ 97320,  # Slovenska demokratska stranka in Slovenska ljudska stranka (SDS in SLS)
+      Q7==2402 ~ 97401,  # Lista Marjana Sarca (LMS) 
+      Q7==2403 ~ 97321,  # Socialni demokrati (SD) 
+      Q7==2404 ~ 97510,  # Nova Slovenija - krs?anski demokrati  (NSi) 
+      Q7==2405 ~ NA_real_,  # Levica
+      Q7==2406 ~ NA_real_,  # Slovenska nacionalna stranka (SNS)
+      Q7==2407 ~ NA_real_,  # Stranka modernega centra (SMC)
+      Q7==2408 ~ NA_real_,  # Stranka Alenke Bratusek (SAB)
+      Q7==2409 ~ 97951,  # Demokrati?na stranka upokojencev Slovenije (DESUS)
+      Q7==2410 ~ NA_real_,  # Dom - domovinska liga (DOM)
+      Q7==2411 ~ NA_real_,  # Zeleni Slovenije  
+      Q7==2412 ~ NA_real_,  # Povezimo se
+      T       ~ NA_real_
+    ),
+    emcs = as.integer(emcs)
+  )
+
+# Check the new dataset 
+
+# EES2019_si_enhcdbk %>%
+#   dplyr::select(partyname, partyname_eng, Q7, emcs)
+
+
 
 # Clean the environment # ==============================================================================
 

--- a/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_sk.R
+++ b/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_sk.R
@@ -1,7 +1,7 @@
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Title: EES2019 enhanced codebook (Slovakia sample)
 # Author: J.Leiser
-# last update: 2021-08-26
+# last update: 2022-03-16
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 # Select the Slovakia codebook and EP results # =========================================================
@@ -59,6 +59,38 @@ EES2019_sk_enhcdbk <-
 # EES2019_sk_enhcdbk %>%
 #   dplyr::select(partyname, partyname_eng, Q7, votesh, seats)
 # now 11 unique parties as expected
+
+# Create a common variable for merging the codebook w/ EMCS # ==========================================
+
+# EES2019_sk_enhcdbk %>%
+#   dplyr::select(partyname, partyname_eng, Q7) %>%
+#   print(., n=nrow(.))
+
+EES2019_sk_enhcdbk %<>% 
+  mutate(
+    emcs = case_when(
+      Q7==2510 ~ 96521,  # Kres?anskodemokraticke hnutie  (KDH) 
+      Q7==2501 ~ NA_real_,  # ?udova strana- Nase Slovensko (?SNS)
+      Q7==2509 ~ 96601,  # Sme rodina
+      Q7==2503 ~ 96423,  # Smer-socialna demokracia  (Smer-SD)
+      Q7==2505 ~ 96610,  # Sloboda a Solidarita (SaS)   
+      Q7==2506 ~ 96630,  # Oby?ajni ?udia a nezavisle osobnosti  (O?aNO)  
+      Q7==2508 ~ 96402,  # Progresivne Slovensko a SPOLU 
+      Q7==2504 ~ NA_real_,  # Slovenska narodna strana (SNS)  
+      Q7==2507 ~ 96410,  # Most-Hid 
+      Q7==2502 ~ 96955,  # Strana mad'arskej koalicie - Magyar Koalicio Partja (SMK-MKP) 
+      Q7==2511 ~ NA_real_,  # Komunisticka strana Slovenska (KSS)
+      T       ~ NA_real_
+    ),
+    emcs = as.integer(emcs)
+  )
+
+# Check the new dataset 
+
+# EES2019_sk_enhcdbk %>%
+#   dplyr::select(partyname, partyname_eng, Q7, emcs)
+
+
 
 # Clean the environment # ==============================================================================
 

--- a/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_uk.R
+++ b/Scripts/aux_data_scripts/country_spec_aux_scripts/EES2019_enhcdbk_uk.R
@@ -1,7 +1,7 @@
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Title: EES2019 enhanced codebook (United Kingdom sample)
-# Author: W.Haeussling
-# last update: 2021-08-27
+# Author: W.Haeussling & J.Leiser
+# last update: 2022-03-16
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 
@@ -58,6 +58,40 @@ EES2019_uk_enhcdbk <-
 
 # EES2019_uk_enhcdbk %>% 
 #   dplyr::select(partyname, partyname_eng, Q7, votesh, seats)
+
+
+# Create a common variable for merging the codebook w/ EMCS # ==========================================
+
+# EES2019_uk_enhcdbk %>%
+#   dplyr::select(partyname, partyname_eng, Q7) %>%
+#   print(., n=nrow(.))
+
+EES2019_uk_enhcdbk %<>% 
+  mutate(
+    emcs = case_when(
+      Q7==2801 ~ 51620,  # Conservative  (Con)  
+      Q7==2802 ~ 51320,  # Labour Party (Lab)
+      Q7==2803 ~ 51421,  # Liberal Democrats (LD)
+      Q7==2804 ~ 51110,  # Green Party (GP)
+      Q7==2805 ~ 51902,  # Scottish National Party (SNP) 
+      Q7==2806 ~ 51951,  # United Kingdom Independence Party (UKIP)
+      Q7==2807 ~ 51702,  # The Brexit Party  
+      Q7==2808 ~ NA_real_,  # Change UK - The Independent Group 
+      Q7==2809 ~ 51901,  # Plaid Cymru (Plaid) 
+      Q7==2810 ~ 51953,  # Sinn Fein (SF) 
+      Q7==2811 ~ 51903,  # Democratic Unionist Party (DUP)
+      Q7==2812 ~ 51904,  # Ulster Unionist Party
+      Q7==2813 ~ NA_real_,  # Social Democratic & Labour Party (SDLP)
+      Q7==2814 ~ NA_real_,  # Independent
+      T       ~ NA_real_
+    ),
+    emcs = as.integer(emcs)
+  )
+
+# Check the new dataset 
+
+# EES2019_uk_enhcdbk %>%
+#   dplyr::select(partyname, partyname_eng, Q7, emcs)
 
 # Clean the environment # ==============================================================================
 


### PR DESCRIPTION
Updated aux_scripts to include emcs variable for Belgium, Bulgaria, Croatia, Czech Rep., Denmark, Germany, Hungary, Ireland, Latvia, Malta, Portugal, Slovakia, Slovenia, UK

Remarks
- emcs variable was only created for parties which have Q7 not missing in EESstacked data and are not missing in the EMCS word document.
- the independent party in Ireland has been set as emcs = NA as I could not ascertain whether the independent party in the EES data and the independent movement in the word document are in fact the same