### PR TITLE
Party selection pipeline

### DIFF
--- a/Scripts/country_spec_scripts/EES2019_be_stack.R
+++ b/Scripts/country_spec_scripts/EES2019_be_stack.R
@@ -54,10 +54,17 @@ ptv_crit <- lapply(el_coll_be,
 
 # Check the seats obtained by each party - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-seats_crit <- lapply(el_coll_be, 
+# seats_crit <- lapply(el_coll_be, 
+#                      function(x) {
+#                        EES2019_cdbk_be[[x]] %>%  
+#                          dplyr::select(partyname, seats) %>% 
+#                          mutate(seats = case_when(seats==0 ~ NA_integer_, T~seats))
+#                      })
+
+votes_crit <- lapply(el_coll_be, 
                      function(x) {
                        EES2019_cdbk_be[[x]] %>%  
-                         dplyr::select(partyname, seats) %>% 
+                         dplyr::select(partyname, seats, votesh) %>% 
                          mutate(seats = case_when(seats==0 ~ NA_integer_, T~seats))
                      })
 

--- a/Scripts/country_spec_scripts/EES2019_bg_stack.R
+++ b/Scripts/country_spec_scripts/EES2019_bg_stack.R
@@ -48,9 +48,14 @@ ptv_crit <-
 
 # Check the seats obtained by each party - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-seats_crit <- 
-  EES2019_cdbk_bg %>% 
-  dplyr::select(partyname_eng, seats)
+# seats_crit <- 
+#   EES2019_cdbk_bg %>% 
+#   dplyr::select(partyname_eng, seats)
+
+votes_crit <- 
+  EES2019_cdbk_bg %>%
+  mutate(seats = case_when(seats==as.integer(0) ~ NA_integer_, T~seats)) %>% 
+  dplyr::select(partyname, votesh, seats)
 
 # seats_crit: 5 parties
 

--- a/Scripts/country_spec_scripts/EES2019_cy_stack.R
+++ b/Scripts/country_spec_scripts/EES2019_cy_stack.R
@@ -29,18 +29,29 @@ respid <-
 
 # Check the parties about which we have the PTV variable # - - - - - - - - - - - - - - - - - - - - - - -
 
+# ptv_crit <-
+#   EES2019_cdbk_cy %>% 
+#   dplyr::select(partyname_eng, Q10_PTV, Q7) 
+
 ptv_crit <-
   EES2019_cdbk_cy %>% 
-  dplyr::select(partyname_eng, Q10_PTV, Q7) 
+  dplyr::select(partyname_eng, Q10_PTV) 
+
 
 #ptv_crit: 6 parties
 
 # Check the seats obtained by each party - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-seats_crit <- 
-  EES2019_cdbk_cy %>% 
-  dplyr::select(partyname_eng, seats) %>% 
-  mutate(seats = case_when(seats==0 ~ NA_integer_, T~seats))
+# seats_crit <- 
+#   EES2019_cdbk_cy %>% 
+#   dplyr::select(partyname_eng, seats) %>% 
+#   mutate(seats = case_when(seats==0 ~ NA_integer_, T~seats))
+
+votes_crit <- 
+  EES2019_cdbk_cy %>%
+  mutate(seats = case_when(seats==as.integer(0) ~ NA_integer_, T~seats)) %>% 
+  dplyr::select(partyname, votesh, seats)
+
 
 # seats_crit: 4 parties
 

--- a/Scripts/country_spec_scripts/EES2019_el_stack.R
+++ b/Scripts/country_spec_scripts/EES2019_el_stack.R
@@ -37,10 +37,15 @@ ptv_crit <-
 
 # Check the seats obtained by each party - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-seats_crit <- 
+# seats_crit <- 
+#   EES2019_cdbk_el %>% 
+#   dplyr::select(partyname_eng, seats) %>% 
+#   mutate(seats = case_when(seats==0 ~ NA_integer_, T~seats))
+
+votes_crit <- 
   EES2019_cdbk_el %>% 
-  dplyr::select(partyname_eng, seats) %>% 
-  mutate(seats = case_when(seats==0 ~ NA_integer_, T~seats))
+  mutate(seats = case_when(seats==as.integer(0) ~ NA_integer_, T~seats)) %>% 
+  dplyr::select(partyname, votesh, seats)
 
 # seats_crit: 6 parties
 

--- a/Scripts/country_spec_scripts/EES2019_hr_stack.R
+++ b/Scripts/country_spec_scripts/EES2019_hr_stack.R
@@ -46,10 +46,15 @@ ptv_crit <-
 
 # Check the seats obtained by each party - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-seats_crit <- 
-  EES2019_cdbk_hr %>% 
-  dplyr::select(partyname, seats) %>% 
-  mutate(seats = case_when(seats==0 ~ NA_integer_, T~seats))
+# seats_crit <- 
+#   EES2019_cdbk_hr %>% 
+#   dplyr::select(partyname, seats) %>% 
+#   mutate(seats = case_when(seats==0 ~ NA_integer_, T~seats))
+
+votes_crit <- 
+  EES2019_cdbk_hr %>%
+  mutate(seats = case_when(seats==as.integer(0) ~ NA_integer_, T~seats)) %>% 
+  dplyr::select(partyname, votesh, seats)
 
 #votes_crit: 6 parties
 

--- a/Scripts/country_spec_scripts/EES2019_nl_stack.R
+++ b/Scripts/country_spec_scripts/EES2019_nl_stack.R
@@ -46,10 +46,15 @@ ptv_crit <-
 
 # Check the seats obtained by each party - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-seats_crit <- 
-  EES2019_cdbk_nl %>% 
-  dplyr::select(partyname, seats) %>% 
-  mutate(seats = case_when(seats==0 ~ NA_integer_, T~seats))
+# seats_crit <- 
+#   EES2019_cdbk_nl %>% 
+#   dplyr::select(partyname, seats) %>% 
+#   mutate(seats = case_when(seats==0 ~ NA_integer_, T~seats))
+
+votes_crit <- 
+  EES2019_cdbk_nl %>%
+  mutate(seats = case_when(seats==as.integer(0) ~ NA_integer_, T~seats)) %>% 
+  dplyr::select(partyname, votesh, seats)
 
 #votes_crit: 9 parties
 


### PR DESCRIPTION
Method used for selecting party in the workflow is:
party <-
  EES2019_cdbk_xx %>%
  dplyr::select(partyname, Q10_PTV, Q7) %>%
  na.omit() %>%
  .$Q7
The method is consistent across all _stack scripts

But: Minor issues
- several files use the (outdated?) seats_crit instead of the votes_crit, I changed the criterion to the up-to-date votes_crit in BE, BG, CY, EL, HR, NL
- CY: ptv_crit also selects for Q7 which no other country script does. I deleted this irregularity
- BC, CY and EL use partyname_eng instead of partyname in the ptv_criterion. I did not change this as encoding problems are likely the cause why partyname_eng was used.